### PR TITLE
chore: remove deploy-docs from workflow dependencies for stable release promotion

### DIFF
--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -295,7 +295,7 @@ jobs:
   dry-run-publish-stable-release:
     name: "[DRY RUN] Publish Stable Release"
     runs-on: ubuntu-latest
-    needs: [dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main, dry-run-deploy-docs]
+    needs: [dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main]
 
     steps:
       - name: Checkout main branch
@@ -318,7 +318,7 @@ jobs:
   dry-run-fast-forward-beta:
     name: "[DRY RUN] Fast-Forward Beta to Main"
     runs-on: ubuntu-latest
-    needs: [dry-run-merge-beta-to-main, dry-run-publish-stable-release]
+    needs: [dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main]
 
     steps:
       - name: Checkout beta branch
@@ -643,13 +643,12 @@ jobs:
   publish-stable-release:
     name: "Publish Stable Release"
     runs-on: ubuntu-latest
-    needs: [merge-beta-to-main, update-changelog-main, update-readme-main, deploy-docs]
+    needs: [merge-beta-to-main, update-changelog-main, update-readme-main]
     # Explicitly check that all prerequisites succeeded
     if: |
       needs.merge-beta-to-main.result == 'success' &&
       needs.update-changelog-main.result == 'success' &&
-      needs.update-readme-main.result == 'success' &&
-      needs.deploy-docs.result == 'success'
+      needs.update-readme-main.result == 'success'
 
     steps:
       - name: Log release creation
@@ -691,7 +690,7 @@ jobs:
   fast-forward-beta:
     name: "Fast-Forward Beta to Main"
     runs-on: ubuntu-latest
-    needs: [merge-beta-to-main, publish-stable-release]
+    needs: [merge-beta-to-main, update-changelog-main, update-readme-main]
 
     steps:
       - name: Checkout beta branch

--- a/SpectrumFederation/SpectrumFederation.toc
+++ b/SpectrumFederation/SpectrumFederation.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: Spectrum Federation
 ## Author: OsulivanAB
-## Version: 0.5.22
+## Version: 0.5.23-beta.1
 ## Notes: Loot profile management and helper tools for guild coordination. Create and manage raid loot profiles, track distributions, and coordinate gear allocation across your guild.
 ## IconTexture: Interface\AddOns\SpectrumFederation\media\Icons\SpectrumFederationIcon
 ## X-Website: https://github.com/OsulivanAB/SpectrumFederation

--- a/docs/development/getting-started/workflows.md
+++ b/docs/development/getting-started/workflows.md
@@ -58,7 +58,7 @@ graph TB
 **Inputs**:
 - `dry_run`: Test promotion without making changes (default: `false`)
 
-**Jobs** (sequential):
+**Jobs**:
 1. **pre-merge-validation**: Validate beta state before merge
 2. **merge-beta-to-main**: Merge beta → main with special handling
    - Use `-X ours` strategy for CHANGELOG.md and README.md
@@ -66,10 +66,11 @@ graph TB
    - Query Blizzard API for Live Interface version
 3. **update-changelog-main**: Update CHANGELOG.md on main
 4. **update-readme-main**: Update README.md badges for main
-5. **deploy-docs**: Deploy documentation to GitHub Pages
-6. **publish-stable-release**: Create stable GitHub release
-7. **fast-forward-beta**: Sync beta to match main
-8. **summary**: Display promotion summary
+5. **In parallel** (after README updates; dry-run phase uses the same graph):
+   - **deploy-docs**: Deploy documentation to GitHub Pages
+   - **publish-stable-release**: Create stable GitHub release
+   - **fast-forward-beta**: Sync beta to match main
+6. **summary**: Display promotion summary
 
 **Safety Features**:
 - Dry-run mode for testing


### PR DESCRIPTION
## Description

Updated the Promote beta to main workflow to allow parallelization

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code improvement without functional changes)
- [x] Documentation update
- [x] Other (please describe):

## Checklist

- [x] I have tested these changes in-game
- [x] My code follows the project's style guidelines
- [x] I have added/updated documentation as needed
- [x] I have added appropriate Debug Logging if necessary
- [x] I have added/updated localization strings in `locale/enUS.lua` if applicable
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published
- [x] I've linked this PR to any related issues in the [repo project](https://github.com/users/OsulivanAB/projects/1).

## Testing

### In-Game Testing Details

**WoW Client Type:**
- [x] Retail
- [ ] Classic
- [ ] PTR
- [ ] Beta

**Game Version:** <!-- e.g., 11.0.2 -->

**Additional Testing Info**

<!-- Describe what you tested in-game and any specific scenarios -->

## Screenshots/Videos

<!-- If applicable, add screenshots or video links to demonstrate the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release promotion job ordering so publish and beta fast-forward no longer wait on docs deploy (and fast-forward no longer waits on publish), which can alter failure/recovery behavior in a critical CI path.
> 
> **Overview**
> Allows **docs deploy**, **stable release publish**, and **beta fast-forward** to run **in parallel** after changelog/README updates in `promote-beta-to-main.yml`.
> 
> Removes `deploy-docs` from `publish-stable-release` prerequisites (including its success `if` check). Also retargets `fast-forward-beta` to depend on merge/changelog/README instead of waiting for publish. The same dependency changes are applied to the dry-run jobs, and workflow docs are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05245ffefd9a9bf639e6b7f12c6e6427badaa423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->