### PR TITLE
Prepare SpectrumFederation 1.0.0 launch candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@ All notable changes to SpectrumFederation will be documented in this file.
 
 
 
+## [1.0.0-beta.1] - 2026-08-11
+
+### Changed
+- Prepared the addon metadata and release documentation for the first stable 1.0.0 release.
+
 ## [0.5.23-beta.1] - 2026-08-11
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!-- STATUS_BADGES_START -->
 ![WoW Version](https://img.shields.io/badge/WoW-12.0.0-00aaff)
 ![Track](https://img.shields.io/badge/Track-Beta-ff8800)
-![Addon Version](https://img.shields.io/badge/Version-0.5.23--beta.1-brightgreen)
+![Addon Version](https://img.shields.io/badge/Version-1.0.0--beta.1-brightgreen)
 
 <!-- STATUS_BADGES_END -->
 

--- a/SpectrumFederation/SpectrumFederation.toc
+++ b/SpectrumFederation/SpectrumFederation.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: Spectrum Federation
 ## Author: OsulivanAB
-## Version: 0.5.23-beta.1
+## Version: 1.0.0-beta.1
 ## Notes: Loot profile management and helper tools for guild coordination. Create and manage raid loot profiles, track distributions, and coordinate gear allocation across your guild.
 ## IconTexture: Interface\AddOns\SpectrumFederation\media\Icons\SpectrumFederationIcon
 ## X-Website: https://github.com/OsulivanAB/SpectrumFederation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Prepares the beta branch for the first stable SpectrumFederation 1.0.0 release. The beta manifest uses `1.0.0-beta.1`; the existing promotion workflow removes the beta suffix and publishes stable `v1.0.0` on `main`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without functional changes)
- [x] Documentation update
- [x] Other (please describe): Release metadata update

## Changes Made

- Updated the authoritative TOC version to `1.0.0-beta.1`.
- Updated the README version badge for the V1 release candidate.
- Added the V1 release candidate to the changelog.
- Audited MkDocs content and addon source; no other current addon-version values require changes.

## Checklist

- [x] In-game testing is not applicable because this change only updates release metadata and documentation
- [x] My code follows the project's style guidelines
- [x] I have added/updated documentation as needed
- [x] Debug logging is not applicable because runtime behavior is unchanged
- [x] Localization updates are not applicable because no user-facing addon strings changed
- [x] My changes generate no new warnings or errors
- [x] Dependent changes are not applicable for this release metadata update
- [x] I've linked this PR to any related issues in the [repo project](https://github.com/users/OsulivanAB/projects/1).

## Testing

### In-Game Testing Details

**WoW Client Type:**
- [x] Retail
- [ ] Classic
- [ ] PTR
- [ ] Beta

**Game Version:** 12.0.1

**Additional Testing Info**

- `python3 .github/scripts/lint_all.py` — passed (65 Lua files, YAML, and Python; zero warnings/errors)
- `python3 .github/scripts/validate_packaging.py` — passed
- `python3 .github/scripts/validate_docs.py` — passed
- `python3 .github/scripts/check_version_bump.py beta` — passed
- Verified the promotion transform produces stable `1.0.0` from `1.0.0-beta.1`

In-game testing is not applicable because runtime code is unchanged.

## Screenshots/Videos

Not applicable for a release metadata and documentation update.

## Additional Notes

This PR targets `beta` by design. Promotion through `promote-beta-to-main.yml` converts `1.0.0-beta.1` to `1.0.0`, updates stable badges/changelog, and publishes `v1.0.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2350a44c-65ae-468b-a248-0c496121433e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2350a44c-65ae-468b-a248-0c496121433e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

