### PR TITLE
Run addon release automation only for addon changes

### DIFF
--- a/.github/workflows/post-merge-beta.yml
+++ b/.github/workflows/post-merge-beta.yml
@@ -6,8 +6,6 @@ on:
       - beta
     paths:
       - 'SpectrumFederation/**'
-      - '.github/scripts/**'
-      - '.github/workflows/**'
 
 concurrency:
   group: beta-release

--- a/.github/workflows/pr-beta-validation.yml
+++ b/.github/workflows/pr-beta-validation.yml
@@ -18,6 +18,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-addon-changes:
+    name: Detect Addon Changes
+    runs-on: ubuntu-latest
+    outputs:
+      addon_changed: ${{ steps.changes.outputs.addon_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for addon changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'SpectrumFederation/')
+          if [[ -n "$CHANGED_FILES" ]]; then
+            echo "addon_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Addon files changed:"
+            echo "$CHANGED_FILES"
+          else
+            echo "addon_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No addon files changed."
+          fi
+
   lint:
     name: Lint Code
     runs-on: ubuntu-latest
@@ -61,6 +89,8 @@ jobs:
 
   check-version-bump:
     name: Check Version Bump
+    needs: detect-addon-changes
+    if: needs.detect-addon-changes.outputs.addon_changed == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-beta-validation.yml
+++ b/.github/workflows/pr-beta-validation.yml
@@ -109,6 +109,8 @@ jobs:
 
   check-duplicate-beta-release:
     name: Check for Duplicate Beta Release
+    needs: detect-addon-changes
+    if: needs.detect-addon-changes.outputs.addon_changed == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pr-beta-validation.yml
+++ b/.github/workflows/pr-beta-validation.yml
@@ -36,7 +36,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'SpectrumFederation/')
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- 'SpectrumFederation/')
           if [[ -n "$CHANGED_FILES" ]]; then
             echo "addon_changed=true" >> "$GITHUB_OUTPUT"
             echo "Addon files changed:"

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -13,12 +13,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  detect-promotion-scope:
+    name: Detect Promotion Scope
+    runs-on: ubuntu-latest
+    outputs:
+      addon_changed: ${{ steps.changes.outputs.addon_changed }}
+
+    steps:
+      - name: Checkout beta branch
+        uses: actions/checkout@v6
+        with:
+          ref: beta
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Check for addon changes
+        id: changes
+        run: |
+          CHANGED_FILES=$(git diff --name-only "origin/main...HEAD" -- 'SpectrumFederation/')
+          if [[ -n "$CHANGED_FILES" ]]; then
+            echo "addon_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Addon files changed between main and beta:"
+            echo "$CHANGED_FILES"
+          else
+            echo "addon_changed=false" >> "$GITHUB_OUTPUT"
+            echo "No addon files changed between main and beta."
+          fi
+
   # ==========================================
   # Phase 1: Dry Run (validation only, no pushes)
   # ==========================================
   dry-run-pre-merge-validation:
     name: "[DRY RUN] Pre-Merge Validation"
     runs-on: ubuntu-latest
+    needs: detect-promotion-scope
 
     steps:
       - name: Checkout beta branch
@@ -52,6 +82,7 @@ jobs:
         run: python3 .github/scripts/validate_docs.py
 
       - name: Verify beta version format
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         run: |
           VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
           echo "Beta version: $VERSION"
@@ -64,13 +95,25 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         id: beta_version
 
+      - name: Verify unchanged addon uses stable version
+        if: needs.detect-promotion-scope.outputs.addon_changed != 'true'
+        run: |
+          VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
+          echo "Unchanged addon version: $VERSION"
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error ::A promotion without addon changes must retain a stable X.Y.Z version"
+            exit 1
+          fi
+
   dry-run-merge-beta-to-main:
     name: "[DRY RUN] Merge Beta to Main"
     runs-on: ubuntu-latest
-    needs: dry-run-pre-merge-validation
+    needs: [detect-promotion-scope, dry-run-pre-merge-validation]
     outputs:
-      stable_version: ${{ steps.remove_beta.outputs.stable_version }}
-      interface: ${{ steps.blizzard.outputs.interface }}
+      addon_changed: ${{ needs.detect-promotion-scope.outputs.addon_changed }}
+      stable_version: ${{ steps.metadata.outputs.stable_version }}
+      interface: ${{ steps.metadata.outputs.interface }}
 
     steps:
       - name: Checkout main branch
@@ -109,11 +152,13 @@ jobs:
           git commit -m "chore: promote beta to main [skip ci]"
 
       - name: Set up Python
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Validate merged TOC version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         run: |
           MERGED_VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
           echo "Merged TOC version: $MERGED_VERSION"
@@ -127,6 +172,7 @@ jobs:
           echo "✓ Merged version contains -beta suffix as expected"
 
       - name: Remove -beta suffix from version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         id: remove_beta
         run: |
           BETA_VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
@@ -141,6 +187,7 @@ jobs:
           git commit -m "chore: update version to $STABLE_VERSION [skip ci]"
 
       - name: Query Blizzard API for live Interface version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         id: blizzard
         run: |
           INTERFACE=$(python3 .github/scripts/blizzard_api.py --environment live --output interface)
@@ -148,6 +195,7 @@ jobs:
           echo "Live Interface version: $INTERFACE"
 
       - name: Update Interface version in TOC
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         run: |
           INTERFACE="${{ steps.blizzard.outputs.interface }}"
           echo "Updating Interface to: $INTERFACE"
@@ -155,6 +203,20 @@ jobs:
           sed -i "s/^## Interface:.*$/## Interface: $INTERFACE/" SpectrumFederation/SpectrumFederation.toc
           git add SpectrumFederation/SpectrumFederation.toc
           git commit -m "chore: update Interface to $INTERFACE [skip ci]" || echo "No Interface changes"
+
+      - name: Set promotion metadata
+        id: metadata
+        run: |
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" ]]; then
+            VERSION="${{ steps.remove_beta.outputs.stable_version }}"
+            INTERFACE="${{ steps.blizzard.outputs.interface }}"
+          else
+            VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
+            INTERFACE=$(grep -E '^## Interface:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Interface://i' | xargs)
+          fi
+
+          echo "stable_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "interface=$INTERFACE" >> "$GITHUB_OUTPUT"
 
       - name: Push changes to main
         if: false  # Dry run - skip push
@@ -295,7 +357,8 @@ jobs:
   dry-run-publish-stable-release:
     name: "[DRY RUN] Publish Stable Release"
     runs-on: ubuntu-latest
-    needs: [dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main]
+    needs: [detect-promotion-scope, dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main]
+    if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
 
     steps:
       - name: Checkout main branch
@@ -358,7 +421,7 @@ jobs:
   dry-run-summary:
     name: "[DRY RUN] Promotion Summary"
     runs-on: ubuntu-latest
-    needs: [dry-run-pre-merge-validation, dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main, dry-run-deploy-docs, dry-run-publish-stable-release, dry-run-fast-forward-beta]
+    needs: [detect-promotion-scope, dry-run-pre-merge-validation, dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main, dry-run-deploy-docs, dry-run-publish-stable-release, dry-run-fast-forward-beta]
     if: always()
 
     steps:
@@ -370,7 +433,13 @@ jobs:
           CHANGELOG_STATUS="${{ needs.dry-run-update-changelog-main.result == 'success' && '✅' || '❌' }}"
           README_STATUS="${{ needs.dry-run-update-readme-main.result == 'success' && '✅' || '❌' }}"
           DOCS_STATUS="${{ needs.dry-run-deploy-docs.result == 'success' && '✅' || '❌' }}"
-          RELEASE_STATUS="${{ needs.dry-run-publish-stable-release.result == 'success' && '✅' || '❌' }}"
+          if [[ "${{ needs.dry-run-publish-stable-release.result }}" == "success" ]]; then
+            RELEASE_STATUS="✅"
+          elif [[ "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
+            RELEASE_STATUS="⏭️"
+          else
+            RELEASE_STATUS="❌"
+          fi
           FASTFORWARD_STATUS="${{ needs.dry-run-fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
@@ -384,6 +453,7 @@ jobs:
 
           echo "$TITLE" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Promotion Type**: ${{ needs.detect-promotion-scope.outputs.addon_changed == 'true' && 'Addon release' || 'Non-addon changes only' }}" >> $GITHUB_STEP_SUMMARY
           echo "**Stable Version**: ${{ needs.dry-run-merge-beta-to-main.outputs.stable_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Interface Version**: ${{ needs.dry-run-merge-beta-to-main.outputs.interface }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -411,11 +481,12 @@ jobs:
   merge-beta-to-main:
     name: "Merge Beta to Main"
     runs-on: ubuntu-latest
-    needs: [dry-run-summary, dry-run-merge-beta-to-main]
+    needs: [detect-promotion-scope, dry-run-summary, dry-run-merge-beta-to-main]
     if: needs.dry-run-merge-beta-to-main.result == 'success'
     outputs:
-      stable_version: ${{ steps.remove_beta.outputs.stable_version }}
-      interface: ${{ steps.blizzard.outputs.interface }}
+      addon_changed: ${{ needs.detect-promotion-scope.outputs.addon_changed }}
+      stable_version: ${{ steps.metadata.outputs.stable_version }}
+      interface: ${{ steps.metadata.outputs.interface }}
 
     steps:
       - name: Log phase transition
@@ -462,11 +533,13 @@ jobs:
           git commit -m "chore: promote beta to main [skip ci]"
 
       - name: Set up Python
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Validate merged TOC version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         run: |
           MERGED_VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
           echo "Merged TOC version: $MERGED_VERSION"
@@ -480,6 +553,7 @@ jobs:
           echo "✓ Merged version contains -beta suffix as expected"
 
       - name: Remove -beta suffix from version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         id: remove_beta
         run: |
           BETA_VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
@@ -494,6 +568,7 @@ jobs:
           git commit -m "chore: update version to $STABLE_VERSION [skip ci]"
 
       - name: Query Blizzard API for live Interface version
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         id: blizzard
         run: |
           INTERFACE=$(python3 .github/scripts/blizzard_api.py --environment live --output interface)
@@ -501,6 +576,7 @@ jobs:
           echo "Live Interface version: $INTERFACE"
 
       - name: Update Interface version in TOC
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
         run: |
           INTERFACE="${{ steps.blizzard.outputs.interface }}"
           echo "Updating Interface to: $INTERFACE"
@@ -508,6 +584,20 @@ jobs:
           sed -i "s/^## Interface:.*$/## Interface: $INTERFACE/" SpectrumFederation/SpectrumFederation.toc
           git add SpectrumFederation/SpectrumFederation.toc
           git commit -m "chore: update Interface to $INTERFACE [skip ci]" || echo "No Interface changes"
+
+      - name: Set promotion metadata
+        id: metadata
+        run: |
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" ]]; then
+            VERSION="${{ steps.remove_beta.outputs.stable_version }}"
+            INTERFACE="${{ steps.blizzard.outputs.interface }}"
+          else
+            VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
+            INTERFACE=$(grep -E '^## Interface:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Interface://i' | xargs)
+          fi
+
+          echo "stable_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "interface=$INTERFACE" >> "$GITHUB_OUTPUT"
 
       - name: Push changes to main
         run: git push origin main
@@ -643,9 +733,10 @@ jobs:
   publish-stable-release:
     name: "Publish Stable Release"
     runs-on: ubuntu-latest
-    needs: [merge-beta-to-main, update-changelog-main, update-readme-main]
+    needs: [detect-promotion-scope, merge-beta-to-main, update-changelog-main, update-readme-main]
     # Explicitly check that all prerequisites succeeded
     if: |
+      needs.detect-promotion-scope.outputs.addon_changed == 'true' &&
       needs.merge-beta-to-main.result == 'success' &&
       needs.update-changelog-main.result == 'success' &&
       needs.update-readme-main.result == 'success'
@@ -728,7 +819,7 @@ jobs:
   final-summary:
     name: "Final Promotion Summary"
     runs-on: ubuntu-latest
-    needs: [merge-beta-to-main, update-changelog-main, update-readme-main, deploy-docs, publish-stable-release, fast-forward-beta]
+    needs: [detect-promotion-scope, merge-beta-to-main, update-changelog-main, update-readme-main, deploy-docs, publish-stable-release, fast-forward-beta]
     if: always()
 
     steps:
@@ -739,7 +830,13 @@ jobs:
           CHANGELOG_STATUS="${{ needs.update-changelog-main.result == 'success' && '✅' || '❌' }}"
           README_STATUS="${{ needs.update-readme-main.result == 'success' && '✅' || '❌' }}"
           DOCS_STATUS="${{ needs.deploy-docs.result == 'success' && '✅' || '❌' }}"
-          RELEASE_STATUS="${{ needs.publish-stable-release.result == 'success' && '✅' || '❌' }}"
+          if [[ "${{ needs.publish-stable-release.result }}" == "success" ]]; then
+            RELEASE_STATUS="✅"
+          elif [[ "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
+            RELEASE_STATUS="⏭️"
+          else
+            RELEASE_STATUS="❌"
+          fi
           FASTFORWARD_STATUS="${{ needs.fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
@@ -753,6 +850,7 @@ jobs:
 
           echo "$TITLE" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Promotion Type**: ${{ needs.detect-promotion-scope.outputs.addon_changed == 'true' && 'Addon release' || 'Non-addon changes only' }}" >> $GITHUB_STEP_SUMMARY
           echo "**Stable Version**: ${{ needs.merge-beta-to-main.outputs.stable_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Interface Version**: ${{ needs.merge-beta-to-main.outputs.interface }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -775,6 +873,10 @@ jobs:
             echo "- Release zip file for addon installation" >> $GITHUB_STEP_SUMMARY
             echo "- Release metadata (release.json)" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog notes" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
+            echo "### ⏭️ Stable Release Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No files under \`SpectrumFederation/**\` changed between main and beta." >> $GITHUB_STEP_SUMMARY
           else
             echo "### ⚠️ Release Creation Failed" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -493,12 +493,24 @@ jobs:
   merge-beta-to-main:
     name: "Merge Beta to Main"
     runs-on: ubuntu-latest
-    needs: [detect-promotion-scope, dry-run-summary, dry-run-merge-beta-to-main]
+    needs: [detect-promotion-scope, dry-run-pre-merge-validation, dry-run-merge-beta-to-main, dry-run-update-changelog-main, dry-run-update-readme-main, dry-run-deploy-docs, dry-run-publish-stable-release, dry-run-fast-forward-beta, dry-run-summary]
     if: |
-      always() &&
+      !cancelled() &&
       needs.detect-promotion-scope.result == 'success' &&
+      needs.dry-run-pre-merge-validation.result == 'success' &&
+      needs.dry-run-merge-beta-to-main.result == 'success' &&
+      needs.dry-run-update-changelog-main.result == 'success' &&
+      needs.dry-run-update-readme-main.result == 'success' &&
+      needs.dry-run-deploy-docs.result == 'success' &&
+      needs.dry-run-fast-forward-beta.result == 'success' &&
       needs.dry-run-summary.result == 'success' &&
-      needs.dry-run-merge-beta-to-main.result == 'success'
+      (
+        needs.dry-run-publish-stable-release.result == 'success' ||
+        (
+          needs.detect-promotion-scope.outputs.addon_changed != 'true' &&
+          needs.dry-run-publish-stable-release.result == 'skipped'
+        )
+      )
     outputs:
       addon_changed: ${{ needs.detect-promotion-scope.outputs.addon_changed }}
       stable_version: ${{ steps.metadata.outputs.stable_version }}

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -448,6 +448,15 @@ jobs:
       - name: Summary
         run: |
           # Determine status emojis based on job results
+          ADDON_CHANGED="${{ needs.detect-promotion-scope.outputs.addon_changed }}"
+          if [[ "$ADDON_CHANGED" == "true" ]]; then
+            PROMOTION_TYPE="Addon release"
+          elif [[ "$ADDON_CHANGED" == "false" ]]; then
+            PROMOTION_TYPE="Non-addon changes only"
+          else
+            PROMOTION_TYPE="Unknown (scope detection failed)"
+          fi
+
           VALIDATION_STATUS="${{ needs.dry-run-pre-merge-validation.result == 'success' && '✅' || '❌' }}"
           MERGE_STATUS="${{ needs.dry-run-merge-beta-to-main.result == 'success' && '✅' || '❌' }}"
           CHANGELOG_STATUS="${{ needs.dry-run-update-changelog-main.result == 'success' && '✅' || '❌' }}"
@@ -464,7 +473,9 @@ jobs:
           FASTFORWARD_STATUS="${{ needs.dry-run-fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
-          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" &&
+          if [[ "$ADDON_CHANGED" != "true" && "$ADDON_CHANGED" != "false" ]]; then
+            TITLE="## [DRY RUN] Promotion Failed ❌"
+          elif [[ "$ADDON_CHANGED" == "true" &&
                 "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
             TITLE="## [DRY RUN] Promotion Failed ❌"
           elif [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
@@ -477,7 +488,7 @@ jobs:
 
           echo "$TITLE" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Promotion Type**: ${{ needs.detect-promotion-scope.outputs.addon_changed == 'true' && 'Addon release' || 'Non-addon changes only' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Promotion Type**: $PROMOTION_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "**Stable Version**: ${{ needs.dry-run-merge-beta-to-main.outputs.stable_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Interface Version**: ${{ needs.dry-run-merge-beta-to-main.outputs.interface }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -880,6 +891,15 @@ jobs:
       - name: Summary
         run: |
           # Determine status emojis based on job results
+          ADDON_CHANGED="${{ needs.detect-promotion-scope.outputs.addon_changed }}"
+          if [[ "$ADDON_CHANGED" == "true" ]]; then
+            PROMOTION_TYPE="Addon release"
+          elif [[ "$ADDON_CHANGED" == "false" ]]; then
+            PROMOTION_TYPE="Non-addon changes only"
+          else
+            PROMOTION_TYPE="Unknown (scope detection failed)"
+          fi
+
           MERGE_STATUS="${{ needs.merge-beta-to-main.result == 'success' && '✅' || '❌' }}"
           CHANGELOG_STATUS="${{ needs.update-changelog-main.result == 'success' && '✅' || '❌' }}"
           README_STATUS="${{ needs.update-readme-main.result == 'success' && '✅' || '❌' }}"
@@ -895,7 +915,9 @@ jobs:
           FASTFORWARD_STATUS="${{ needs.fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
-          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" &&
+          if [[ "$ADDON_CHANGED" != "true" && "$ADDON_CHANGED" != "false" ]]; then
+            TITLE="## Promotion Failed ❌"
+          elif [[ "$ADDON_CHANGED" == "true" &&
                 "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
             TITLE="## Promotion Failed ❌"
           elif [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
@@ -908,7 +930,7 @@ jobs:
 
           echo "$TITLE" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Promotion Type**: ${{ needs.detect-promotion-scope.outputs.addon_changed == 'true' && 'Addon release' || 'Non-addon changes only' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Promotion Type**: $PROMOTION_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "**Stable Version**: ${{ needs.merge-beta-to-main.outputs.stable_version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Interface Version**: ${{ needs.merge-beta-to-main.outputs.interface }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -239,15 +239,22 @@ jobs:
           ref: main
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Skip changelog update for non-addon promotion
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed != 'true'
+        run: echo "No addon changes; preserving the existing stable release notes."
+
       - name: Set up Python
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install dependencies
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed == 'true'
         run: pip install requests
 
       - name: Update CHANGELOG.md
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: main
@@ -255,6 +262,7 @@ jobs:
           python3 .github/scripts/update_changelog.py
 
       - name: Commit changelog changes
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -447,7 +455,8 @@ jobs:
           DOCS_STATUS="${{ needs.dry-run-deploy-docs.result == 'success' && '✅' || '❌' }}"
           if [[ "${{ needs.dry-run-publish-stable-release.result }}" == "success" ]]; then
             RELEASE_STATUS="✅"
-          elif [[ "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+                  "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
             RELEASE_STATUS="⏭️"
           else
             RELEASE_STATUS="❌"
@@ -455,7 +464,10 @@ jobs:
           FASTFORWARD_STATUS="${{ needs.dry-run-fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" &&
+                "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
+            TITLE="## [DRY RUN] Promotion Failed ❌"
+          elif [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             TITLE="## [DRY RUN] Promotion Failed ❌"
           elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             TITLE="## [DRY RUN] Promotion Cancelled ⚠️"
@@ -647,15 +659,22 @@ jobs:
           ref: main
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - name: Skip changelog update for non-addon promotion
+        if: needs.merge-beta-to-main.outputs.addon_changed != 'true'
+        run: echo "No addon changes; preserving the existing stable release notes."
+
       - name: Set up Python
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install dependencies
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'true'
         run: pip install requests
 
       - name: Update CHANGELOG.md
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: main
@@ -663,6 +682,7 @@ jobs:
           python3 .github/scripts/update_changelog.py
 
       - name: Commit changelog changes
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -675,6 +695,7 @@ jobs:
           fi
 
       - name: Push changelog to main
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'true'
         run: |
           git pull --rebase origin main
           git push
@@ -865,7 +886,8 @@ jobs:
           DOCS_STATUS="${{ needs.deploy-docs.result == 'success' && '✅' || '❌' }}"
           if [[ "${{ needs.publish-stable-release.result }}" == "success" ]]; then
             RELEASE_STATUS="✅"
-          elif [[ "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+                  "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
             RELEASE_STATUS="⏭️"
           else
             RELEASE_STATUS="❌"
@@ -873,7 +895,10 @@ jobs:
           FASTFORWARD_STATUS="${{ needs.fast-forward-beta.result == 'success' && '✅' || '❌' }}"
 
           # Determine overall status
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" &&
+                "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
+            TITLE="## Promotion Failed ❌"
+          elif [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             TITLE="## Promotion Failed ❌"
           elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             TITLE="## Promotion Cancelled ⚠️"
@@ -906,7 +931,8 @@ jobs:
             echo "- Release zip file for addon installation" >> $GITHUB_STEP_SUMMARY
             echo "- Release metadata (release.json)" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog notes" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+                  "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
             echo "### ⏭️ Stable Release Skipped" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "No files under \`SpectrumFederation/**\` changed between main and beta." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch main branch
-        run: git fetch origin main
+        run: git fetch origin main:refs/remotes/origin/main
 
       - name: Check for addon changes
         id: changes

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -96,7 +96,7 @@ jobs:
         id: beta_version
 
       - name: Verify unchanged addon uses stable version
-        if: needs.detect-promotion-scope.outputs.addon_changed != 'true'
+        if: needs.detect-promotion-scope.outputs.addon_changed == 'false'
         run: |
           VERSION=$(grep -E '^## Version:' SpectrumFederation/SpectrumFederation.toc | head -n1 | sed 's/^## Version://i' | xargs)
           echo "Unchanged addon version: $VERSION"
@@ -240,7 +240,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Skip changelog update for non-addon promotion
-        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed != 'true'
+        if: needs.dry-run-merge-beta-to-main.outputs.addon_changed == 'false'
         run: echo "No addon changes; preserving the existing stable release notes."
 
       - name: Set up Python
@@ -455,7 +455,7 @@ jobs:
           DOCS_STATUS="${{ needs.dry-run-deploy-docs.result == 'success' && '✅' || '❌' }}"
           if [[ "${{ needs.dry-run-publish-stable-release.result }}" == "success" ]]; then
             RELEASE_STATUS="✅"
-          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "false" &&
                   "${{ needs.dry-run-publish-stable-release.result }}" == "skipped" ]]; then
             RELEASE_STATUS="⏭️"
           else
@@ -519,7 +519,7 @@ jobs:
       (
         needs.dry-run-publish-stable-release.result == 'success' ||
         (
-          needs.detect-promotion-scope.outputs.addon_changed != 'true' &&
+          needs.detect-promotion-scope.outputs.addon_changed == 'false' &&
           needs.dry-run-publish-stable-release.result == 'skipped'
         )
       )
@@ -660,7 +660,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Skip changelog update for non-addon promotion
-        if: needs.merge-beta-to-main.outputs.addon_changed != 'true'
+        if: needs.merge-beta-to-main.outputs.addon_changed == 'false'
         run: echo "No addon changes; preserving the existing stable release notes."
 
       - name: Set up Python
@@ -886,7 +886,7 @@ jobs:
           DOCS_STATUS="${{ needs.deploy-docs.result == 'success' && '✅' || '❌' }}"
           if [[ "${{ needs.publish-stable-release.result }}" == "success" ]]; then
             RELEASE_STATUS="✅"
-          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "false" &&
                   "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
             RELEASE_STATUS="⏭️"
           else
@@ -931,7 +931,7 @@ jobs:
             echo "- Release zip file for addon installation" >> $GITHUB_STEP_SUMMARY
             echo "- Release metadata (release.json)" >> $GITHUB_STEP_SUMMARY
             echo "- Changelog notes" >> $GITHUB_STEP_SUMMARY
-          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" != "true" &&
+          elif [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "false" &&
                   "${{ needs.publish-stable-release.result }}" == "skipped" ]]; then
             echo "### ⏭️ Stable Release Skipped" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/promote-beta-to-main.yml
+++ b/.github/workflows/promote-beta-to-main.yml
@@ -149,7 +149,12 @@ jobs:
             exit 1
           fi
 
-          git commit -m "chore: promote beta to main [skip ci]"
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" ]]; then
+            COMMIT_MESSAGE="chore: promote beta to main [skip ci]"
+          else
+            COMMIT_MESSAGE="chore: promote non-addon changes to main [skip ci]"
+          fi
+          git commit -m "$COMMIT_MESSAGE"
 
       - name: Set up Python
         if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
@@ -361,10 +366,17 @@ jobs:
     if: needs.detect-promotion-scope.outputs.addon_changed == 'true'
 
     steps:
-      - name: Checkout main branch
+      - name: Checkout beta branch
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: beta
+
+      - name: Prepare simulated stable addon
+        run: |
+          VERSION="${{ needs.dry-run-merge-beta-to-main.outputs.stable_version }}"
+          INTERFACE="${{ needs.dry-run-merge-beta-to-main.outputs.interface }}"
+          sed -i "s/^## Version:.*$/## Version: $VERSION/" SpectrumFederation/SpectrumFederation.toc
+          sed -i "s/^## Interface:.*$/## Interface: $INTERFACE/" SpectrumFederation/SpectrumFederation.toc
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -482,7 +494,11 @@ jobs:
     name: "Merge Beta to Main"
     runs-on: ubuntu-latest
     needs: [detect-promotion-scope, dry-run-summary, dry-run-merge-beta-to-main]
-    if: needs.dry-run-merge-beta-to-main.result == 'success'
+    if: |
+      always() &&
+      needs.detect-promotion-scope.result == 'success' &&
+      needs.dry-run-summary.result == 'success' &&
+      needs.dry-run-merge-beta-to-main.result == 'success'
     outputs:
       addon_changed: ${{ needs.detect-promotion-scope.outputs.addon_changed }}
       stable_version: ${{ steps.metadata.outputs.stable_version }}
@@ -530,7 +546,12 @@ jobs:
             exit 1
           fi
 
-          git commit -m "chore: promote beta to main [skip ci]"
+          if [[ "${{ needs.detect-promotion-scope.outputs.addon_changed }}" == "true" ]]; then
+            COMMIT_MESSAGE="chore: promote beta to main [skip ci]"
+          else
+            COMMIT_MESSAGE="chore: promote non-addon changes to main [skip ci]"
+          fi
+          git commit -m "$COMMIT_MESSAGE"
 
       - name: Set up Python
         if: needs.detect-promotion-scope.outputs.addon_changed == 'true'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Scope beta PR release checks, beta post-merge publishing, and main promotion packaging to changes under `SpectrumFederation/`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Detect addon changes using pull request and branch merge bases, with promotion pinned to `origin/main`.
- Run `Check Version Bump` and `Check for Duplicate Beta Release` only when addon files changed.
- Trigger `Post-Merge Beta` only for addon-folder changes.
- Detect whether promotion from `beta` to `main` contains addon changes.
- Skip beta-version conversion, Interface mutation, and stable-release packaging in both promotion phases when the addon is unchanged.
- Package the simulated promoted addon during dry-run release validation.
- Require every applicable dry-run job to succeed before the actual promotion phase; accept a skipped package job only for explicit non-addon promotions.
- Preserve existing stable release notes by making non-addon changelog jobs successful no-ops.
- Preserve promotion metadata and continue README, documentation, and branch synchronization for non-addon promotions.
- Give non-addon promotion commits a distinct message so release rollback selection remains isolated.
- Report addon, non-addon, and unknown promotion scope accurately; unknown scope is a failure.

## Checklist

- [x] I have tested these changes in-game (not applicable to CI-only changes)
- [x] My code follows the project's style guidelines
- [x] I have added/updated documentation as needed (not applicable)
- [x] I have added appropriate Debug Logging if necessary (not applicable)
- [x] I have added/updated localization strings in `locale/enUS.lua` if applicable (not applicable)
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published (none)
- [x] I've linked this PR to any related issues in the [repo project](https://github.com/users/OsulivanAB/projects/1) (none provided).

## Testing

### In-Game Testing Details

**WoW Client Type:**
- [x] Retail
- [ ] Classic
- [ ] PTR
- [ ] Beta

**Game Version:** Not applicable

**Additional Testing Info**

- `python3 .github/scripts/lint_all.py` passed.
- `python3 .github/scripts/validate_packaging.py` passed.
- `actionlint` passed with only the workflow's pre-existing intentional constant-false dry-run guards excluded.
- Promotion scope detection passed for addon and non-addon histories.
- Stable packaging completed successfully in dry-run mode.
- Phase-gate tests confirmed addon success and explicit non-addon skip paths proceed, while skipped addon packaging and other dry-run failures block promotion.
- Summary tests confirmed true, false, and unknown scope are classified correctly.
- All three Bugbot review comments were reproduced or assessed and are fully repaired.

## Screenshots/Videos

Not applicable.

## Additional Notes

This is a CI-only change; in-game testing is not applicable. Rollback's existing OR-based commit lookup remains outside this change and is not worsened by the distinct non-addon promotion commit message.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01f0d423-b63d-4ded-a758-ce2a4a1826a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f0d423-b63d-4ded-a758-ce2a4a1826a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

