### PR TITLE
Add Reward Pot loot mode alongside Point Based

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,6 +30,7 @@ read_globals = {
   "C_DateAndTime",
   "GameTooltip",
   "GameTooltip_Hide",
+  "GetCoinTextureString",
   "Settings",
   "UIParent",
   "UIPanelCloseButton",

--- a/SpectrumFederation/SpectrumFederation.toc
+++ b/SpectrumFederation/SpectrumFederation.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: Spectrum Federation
 ## Author: OsulivanAB
-## Version: 1.0.2
+## Version: 1.1.0-beta.1
 ## Notes: Loot profile management and helper tools for guild coordination. Create and manage raid loot profiles, track distributions, and coordinate gear allocation across your guild.
 ## IconTexture: Interface\AddOns\SpectrumFederation\media\Icons\SpectrumFederationIcon
 ## X-Website: https://github.com/OsulivanAB/SpectrumFederation

--- a/SpectrumFederation/modules/LootHelper/Events.lua
+++ b/SpectrumFederation/modules/LootHelper/Events.lua
@@ -80,6 +80,9 @@ function E:_TryHookLootProfile()
     Hook("ImportSnapshot",  "LP:")
     Hook("SetProfileName",  "LP:")
     Hook("SetPointName",    "LP:")
+    Hook("SetLootMode",     "LP:")
+    Hook("SetRewardPotConfig", "LP:")
+    Hook("AdjustRewardPot", "LP:")
 
     return okAny
 end
@@ -102,6 +105,8 @@ function E:_TryHookMember()
     -- Points / membership-related changes
     Hook("IncrementPoints",       "M:")
     Hook("DecrementPoints",       "M:")
+    Hook("IncrementAttendance",   "M:")
+    Hook("DecrementAttendance",   "M:")
     Hook("ToggleEquipment",       "M:")
 
     return okAny

--- a/SpectrumFederation/modules/LootHelper/LootHelper.lua
+++ b/SpectrumFederation/modules/LootHelper/LootHelper.lua
@@ -316,6 +316,9 @@ function SF:RehydrateLootHelperDB()
 			if profile._EnsureOwnerIsAdmin then
 				profile:_EnsureOwnerIsAdmin()
 			end
+			if profile._EnsureRewardPotConfig then
+				profile:_EnsureRewardPotConfig()
+			end
 		end
 	end
 

--- a/SpectrumFederation/modules/LootHelper/LootLogValidators.lua
+++ b/SpectrumFederation/modules/LootHelper/LootLogValidators.lua
@@ -331,5 +331,132 @@ function LootLogValidators.ValidateMainSwapData(eventData)
     return true
 end
 
+local VALID_LOOT_MODES = {
+    point_based = true,
+    reward_pot = true,
+}
+
+local VALID_DEDUCTION_TYPES = {
+    flat = true,
+    percent = true,
+}
+
+-- Function to validate the LOOT_MODE_CHANGE event data
+-- @param eventData (table) - Event data to validate
+-- @return (boolean) - True if valid, false otherwise
+function LootLogValidators.ValidateLootModeChangeData(eventData)
+    local oldMode = eventData.oldMode
+    local newMode = eventData.newMode
+
+    if type(oldMode) ~= "string" or not VALID_LOOT_MODES[oldMode] then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid oldMode in LOOT_MODE_CHANGE: %s", tostring(oldMode))
+        end
+        return false
+    end
+
+    if type(newMode) ~= "string" or not VALID_LOOT_MODES[newMode] then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid newMode in LOOT_MODE_CHANGE: %s", tostring(newMode))
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Function to validate the REWARD_POT_CONFIG_CHANGE event data
+-- @param eventData (table) - Event data to validate
+-- @return (boolean) - True if valid, false otherwise
+function LootLogValidators.ValidateRewardPotConfigChangeData(eventData)
+    local startingPotCopper = math.floor(tonumber(eventData.startingPotCopper) or -1)
+    local deductionType = eventData.deductionType
+    local deductionValue = tonumber(eventData.deductionValue)
+
+    if startingPotCopper < 0 then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid startingPotCopper in REWARD_POT_CONFIG_CHANGE: %s", tostring(eventData.startingPotCopper))
+        end
+        return false
+    end
+
+    if type(deductionType) ~= "string" or not VALID_DEDUCTION_TYPES[deductionType] then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid deductionType in REWARD_POT_CONFIG_CHANGE: %s", tostring(deductionType))
+        end
+        return false
+    end
+
+    if not deductionValue or deductionValue < 0 then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid deductionValue in REWARD_POT_CONFIG_CHANGE: %s", tostring(eventData.deductionValue))
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Function to validate the REWARD_POT_CHANGE event data
+-- @param eventData (table) - Event data to validate
+-- @param POINT_CHANGE_TYPES (table) - Increment/decrement constants
+-- @return (boolean) - True if valid, false otherwise
+function LootLogValidators.ValidateRewardPotChangeData(eventData, POINT_CHANGE_TYPES)
+    local changeType = eventData.change
+    local amount = math.floor(tonumber(eventData.amount) or 0)
+
+    if changeType ~= POINT_CHANGE_TYPES.INCREMENT and changeType ~= POINT_CHANGE_TYPES.DECREMENT then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid reward pot change type: %s", tostring(changeType))
+        end
+        return false
+    end
+
+    if amount <= 0 then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid reward pot change amount: %s", tostring(eventData.amount))
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Function to validate the ATTENDANCE_CHANGE event data
+-- @param eventData (table) - Event data to validate
+-- @param POINT_CHANGE_TYPES (table) - Increment/decrement constants
+-- @return (boolean) - True if valid, false otherwise
+function LootLogValidators.ValidateAttendanceChangeData(eventData, POINT_CHANGE_TYPES)
+    local memberID = eventData.member
+    local changeType = eventData.change
+    local amount = eventData.amount
+
+    if not LootLogValidators.MemberExistsInProfiles(memberID) then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Attendance change log references non-existent member: %s", tostring(memberID))
+        end
+        return false
+    end
+
+    if changeType ~= POINT_CHANGE_TYPES.INCREMENT and changeType ~= POINT_CHANGE_TYPES.DECREMENT then
+        if SF.Debug then
+            SF.Debug:Warn("LOOTLOG", "Invalid attendance change type in log for member %s: %s", tostring(memberID), tostring(changeType))
+        end
+        return false
+    end
+
+    if amount ~= nil then
+        amount = tonumber(amount)
+        if not amount or amount <= 0 then
+            if SF.Debug then
+                SF.Debug:Warn("LOOTLOG", "Invalid attendance change amount in log for member %s: %s", tostring(memberID), tostring(eventData.amount))
+            end
+            return false
+        end
+    end
+
+    return true
+end
+
 -- Export to namespace
 SF.LootLogValidators = LootLogValidators

--- a/SpectrumFederation/modules/LootHelper/LootLogs.lua
+++ b/SpectrumFederation/modules/LootHelper/LootLogs.lua
@@ -20,7 +20,11 @@ local EVENT_TYPES = {
     SAFEMODE_ON_COMBAT_CHANGE   = "SAFEMODE_ON_COMBAT_CHANGE",
     ADMIN_ADDED                 = "ADMIN_ADDED",
     ADMIN_REMOVED               = "ADMIN_REMOVED",
-    MAIN_SWAP                   = "MAIN_SWAP"
+    MAIN_SWAP                   = "MAIN_SWAP",
+    LOOT_MODE_CHANGE            = "LOOT_MODE_CHANGE",
+    REWARD_POT_CONFIG_CHANGE    = "REWARD_POT_CONFIG_CHANGE",
+    REWARD_POT_CHANGE           = "REWARD_POT_CHANGE",
+    ATTENDANCE_CHANGE           = "ATTENDANCE_CHANGE",
 }
 
 local POINT_CHANGE_TYPES = {
@@ -77,6 +81,28 @@ local EVENT_DATA_TEMPLATES = {
     [EVENT_TYPES.MAIN_SWAP] = {
         member = "", -- "Name-Realm" (the new/target character)
         sourceMember = "" -- "Name-Realm" (the old character that was consolidated)
+    },
+    [EVENT_TYPES.LOOT_MODE_CHANGE] = {
+        oldMode = "",
+        newMode = ""
+    },
+    [EVENT_TYPES.REWARD_POT_CONFIG_CHANGE] = {
+        startingPotCopper = 0,
+        deductionType = "",
+        deductionValue = 0
+    },
+    [EVENT_TYPES.REWARD_POT_CHANGE] = {
+        change = "", -- INCREMENT/DECREMENT
+        amount = 0 -- copper
+        -- @field reason string|nil MANUAL or RAID_DEDUCTION
+        -- @field deductionType string|nil flat or percent at the time of a raid deduction
+        -- @field percent number|nil percent used when deductionType is percent
+    },
+    [EVENT_TYPES.ATTENDANCE_CHANGE] = {
+        member = "",
+        change = "" -- INCREMENT/DECREMENT
+        -- @field amount number|nil positive attendance amount
+        -- @field reason string|nil RAID_CHECK or MANUAL
     }
 }
 
@@ -167,6 +193,15 @@ function LootLog.new(eventType, eventData, opts)
             end
             return nil
         end
+
+        if eventType == EVENT_TYPES.LOOT_MODE_CHANGE then
+            if type(ap.IsCurrentUserOwner) ~= "function" or not ap:IsCurrentUserOwner() then
+                if SF.Debug then
+                    SF.Debug:Warn("LOOTLOG", "Current user is not the owner; cannot change loot mode")
+                end
+                return nil
+            end
+        end
     end
 
     -- Validate event type
@@ -227,6 +262,22 @@ function LootLog.new(eventType, eventData, opts)
         end
     elseif eventType == EVENT_TYPES.MAIN_SWAP then
         if not SF.LootLogValidators.ValidateMainSwapData(eventData) then
+            return nil
+        end
+    elseif eventType == EVENT_TYPES.LOOT_MODE_CHANGE then
+        if not SF.LootLogValidators.ValidateLootModeChangeData(eventData) then
+            return nil
+        end
+    elseif eventType == EVENT_TYPES.REWARD_POT_CONFIG_CHANGE then
+        if not SF.LootLogValidators.ValidateRewardPotConfigChangeData(eventData) then
+            return nil
+        end
+    elseif eventType == EVENT_TYPES.REWARD_POT_CHANGE then
+        if not SF.LootLogValidators.ValidateRewardPotChangeData(eventData, POINT_CHANGE_TYPES) then
+            return nil
+        end
+    elseif eventType == EVENT_TYPES.ATTENDANCE_CHANGE then
+        if not SF.LootLogValidators.ValidateAttendanceChangeData(eventData, POINT_CHANGE_TYPES) then
             return nil
         end
     end
@@ -321,6 +372,31 @@ function LootLog.GetPointChangeAmount(eventData)
     end
 
     return DEFAULT_POINT_CHANGE_AMOUNT
+end
+
+function LootLog.GetAttendanceChangeAmount(eventData)
+    if type(eventData) ~= "table" then
+        return 1
+    end
+
+    local amount = tonumber(eventData.amount)
+    if amount and amount > 0 then
+        return amount
+    end
+
+    return 1
+end
+
+function LootLog.GetRewardPotChangeAmount(eventData)
+    if type(eventData) ~= "table" then
+        return 0
+    end
+
+    local amount = math.floor(tonumber(eventData.amount) or 0)
+    if amount < 0 then
+        return 0
+    end
+    return amount
 end
 
 -- Function to get the Unique ID of this log entry

--- a/SpectrumFederation/modules/LootHelper/Members.lua
+++ b/SpectrumFederation/modules/LootHelper/Members.lua
@@ -147,6 +147,7 @@ function Member.new(identifier, role, class)
     instance.className = instance.class
     
     instance.pointBalance = 0
+    instance.attendanceBalance = 0
     instance.most_recent_pre_raid_check_whisper = nil
     instance.most_recent_raid_check_whisper = nil
     
@@ -309,6 +310,12 @@ function Member:GetPointBalance()
     return self.pointBalance
 end
 
+-- Function to get the current attendance balance
+-- @return (number) - Current attendance balance
+function Member:GetAttendanceBalance()
+    return tonumber(self.attendanceBalance) or 0
+end
+
 function Member:GetMostRecentPreRaidCheckWhisper()
     return tonumber(self.most_recent_pre_raid_check_whisper) or nil
 end
@@ -457,6 +464,121 @@ function Member:DecrementPoints(metadata)
     return true
 end
 
+local ATTENDANCE_STEP = 1
+
+local function IsActiveProfileRewardPot()
+    local activeProfile = SF.lootHelperDB and SF.lootHelperDB.activeProfile
+    return activeProfile and activeProfile.IsRewardPotMode and activeProfile:IsRewardPotMode()
+end
+
+-- Function to increment attendance by 1 (or opts.amount)
+-- @param opts table|nil Optional amount, reason, and log author
+-- @return (boolean) - True if successful, false otherwise
+function Member:IncrementAttendance(opts)
+    if not CanCurrentUserEditActiveProfile() then
+        return false
+    end
+
+    local logEventType = SF.LootLogEventTypes.ATTENDANCE_CHANGE
+    local logEventData = SF.LootLog.GetEventDataTemplate(logEventType)
+    logEventData.member = self:GetFullIdentifier()
+    logEventData.change = SF.LootLogPointChangeTypes.INCREMENT
+    if opts and opts.amount ~= nil then
+        logEventData.amount = tonumber(opts.amount) or ATTENDANCE_STEP
+    else
+        logEventData.amount = ATTENDANCE_STEP
+    end
+    if opts and opts.reason then
+        logEventData.reason = opts.reason
+    end
+
+    local logOpts = {}
+    if opts and opts.logAuthor then
+        logOpts.author = opts.logAuthor
+    end
+    if opts and opts.timestamp then
+        logOpts.timestamp = opts.timestamp
+    end
+    local logEntry = SF.LootLog.new(logEventType, logEventData, logOpts)
+    if not logEntry then
+        SF:PrintError("Failed to create loot log entry for attendance increment.")
+        if SF.Debug then
+            SF.Debug:Error("MEMBER", "Failed to create loot log entry for attendance increment for %s", self:GetFullIdentifier())
+        end
+        return false
+    end
+
+    local amount = SF.LootLog.GetAttendanceChangeAmount(logEventData)
+    local oldBalance = tonumber(self.attendanceBalance) or 0
+    self.attendanceBalance = oldBalance + amount
+
+    AddLootLogToActiveProfile(logEntry)
+
+    if SF.Debug then
+        SF.Debug:Verbose("MEMBER", "%s attendance incremented: %s -> %s", self:GetFullIdentifier(), tostring(oldBalance), tostring(self.attendanceBalance))
+    end
+    return true
+end
+
+-- Function to decrement attendance, never going below zero
+-- @param opts table|nil Optional amount, reason, and log author
+-- @return (boolean) - True if successful, false otherwise
+function Member:DecrementAttendance(opts)
+    if not CanCurrentUserEditActiveProfile() then
+        return false
+    end
+
+    local oldBalance = tonumber(self.attendanceBalance) or 0
+    if oldBalance <= 0 then
+        return false
+    end
+
+    local requested = ATTENDANCE_STEP
+    if opts and opts.amount ~= nil then
+        requested = tonumber(opts.amount) or ATTENDANCE_STEP
+    end
+    if requested <= 0 then
+        return false
+    end
+    if requested > oldBalance then
+        requested = oldBalance
+    end
+
+    local logEventType = SF.LootLogEventTypes.ATTENDANCE_CHANGE
+    local logEventData = SF.LootLog.GetEventDataTemplate(logEventType)
+    logEventData.member = self:GetFullIdentifier()
+    logEventData.change = SF.LootLogPointChangeTypes.DECREMENT
+    logEventData.amount = requested
+    if opts and opts.reason then
+        logEventData.reason = opts.reason
+    end
+
+    local logOpts = {}
+    if opts and opts.logAuthor then
+        logOpts.author = opts.logAuthor
+    end
+    if opts and opts.timestamp then
+        logOpts.timestamp = opts.timestamp
+    end
+    local logEntry = SF.LootLog.new(logEventType, logEventData, logOpts)
+    if not logEntry then
+        SF:PrintError("Failed to create loot log entry for attendance decrement.")
+        if SF.Debug then
+            SF.Debug:Error("MEMBER", "Failed to create loot log entry for attendance decrement for %s", self:GetFullIdentifier())
+        end
+        return false
+    end
+
+    self.attendanceBalance = oldBalance - requested
+
+    AddLootLogToActiveProfile(logEntry)
+
+    if SF.Debug then
+        SF.Debug:Verbose("MEMBER", "%s attendance decremented: %s -> %s", self:GetFullIdentifier(), tostring(oldBalance), tostring(self.attendanceBalance))
+    end
+    return true
+end
+
 function Member:ApplyAwardedItem(slot, metadata)
     metadata = metadata or {}
 
@@ -513,38 +635,46 @@ function Member:ApplyAwardedItem(slot, metadata)
         return false
     end
 
-    local pointLogEventType = SF.LootLogEventTypes.POINT_CHANGE
-    local pointLogEventData = SF.LootLog.GetEventDataTemplate(pointLogEventType)
+    local skipPoints = IsActiveProfileRewardPot()
+    local pointLogEntry = nil
     local pointAmount = EQUIPMENT_AWARD_POINT_COST
-    pointLogEventData.member = self:GetFullIdentifier()
-    pointLogEventData.change = SF.LootLogPointChangeTypes.DECREMENT
-    pointLogEventData.amount = pointAmount
-    if metadata.reason ~= nil then
-        pointLogEventData.reason = tostring(metadata.reason)
-    end
-    if metadata.source ~= nil then
-        pointLogEventData.source = tostring(metadata.source)
-    end
-    if metadata.rollType ~= nil then
-        pointLogEventData.rollType = tostring(metadata.rollType)
-    end
-    if metadata.itemLink ~= nil then
-        pointLogEventData.itemLink = tostring(metadata.itemLink)
-    end
-
-    local pointLogEntry = SF.LootLog.new(pointLogEventType, pointLogEventData, logOpts)
-    if not pointLogEntry then
-        if SF.Debug then
-            SF.Debug:Error("MEMBER", "Failed to create point log for awarded item for %s", self:GetFullIdentifier())
+    if not skipPoints then
+        local pointLogEventType = SF.LootLogEventTypes.POINT_CHANGE
+        local pointLogEventData = SF.LootLog.GetEventDataTemplate(pointLogEventType)
+        pointLogEventData.member = self:GetFullIdentifier()
+        pointLogEventData.change = SF.LootLogPointChangeTypes.DECREMENT
+        pointLogEventData.amount = pointAmount
+        if metadata.reason ~= nil then
+            pointLogEventData.reason = tostring(metadata.reason)
         end
-        return false
+        if metadata.source ~= nil then
+            pointLogEventData.source = tostring(metadata.source)
+        end
+        if metadata.rollType ~= nil then
+            pointLogEventData.rollType = tostring(metadata.rollType)
+        end
+        if metadata.itemLink ~= nil then
+            pointLogEventData.itemLink = tostring(metadata.itemLink)
+        end
+
+        pointLogEntry = SF.LootLog.new(pointLogEventType, pointLogEventData, logOpts)
+        if not pointLogEntry then
+            if SF.Debug then
+                SF.Debug:Error("MEMBER", "Failed to create point log for awarded item for %s", self:GetFullIdentifier())
+            end
+            return false
+        end
     end
 
     self.armor[slot] = true
-    self.pointBalance = self.pointBalance - pointAmount
+    if not skipPoints then
+        self.pointBalance = self.pointBalance - pointAmount
+    end
 
     AddLootLogToActiveProfile(armorLogEntry)
-    AddLootLogToActiveProfile(pointLogEntry)
+    if pointLogEntry then
+        AddLootLogToActiveProfile(pointLogEntry)
+    end
 
     if SF.Debug then
         SF.Debug:Info(
@@ -620,38 +750,46 @@ function Member:ClearAwardedItem(slot, metadata)
         return false
     end
 
-    local pointLogEventType = SF.LootLogEventTypes.POINT_CHANGE
-    local pointLogEventData = SF.LootLog.GetEventDataTemplate(pointLogEventType)
+    local skipPoints = IsActiveProfileRewardPot()
+    local pointLogEntry = nil
     local pointAmount = EQUIPMENT_AWARD_POINT_COST
-    pointLogEventData.member = self:GetFullIdentifier()
-    pointLogEventData.change = SF.LootLogPointChangeTypes.INCREMENT
-    pointLogEventData.amount = pointAmount
-    if metadata.reason ~= nil then
-        pointLogEventData.reason = tostring(metadata.reason)
-    end
-    if metadata.source ~= nil then
-        pointLogEventData.source = tostring(metadata.source)
-    end
-    if metadata.rollType ~= nil then
-        pointLogEventData.rollType = tostring(metadata.rollType)
-    end
-    if metadata.itemLink ~= nil then
-        pointLogEventData.itemLink = tostring(metadata.itemLink)
-    end
-
-    local pointLogEntry = SF.LootLog.new(pointLogEventType, pointLogEventData, logOpts)
-    if not pointLogEntry then
-        if SF.Debug then
-            SF.Debug:Error("MEMBER", "Failed to create point clear log for %s", self:GetFullIdentifier())
+    if not skipPoints then
+        local pointLogEventType = SF.LootLogEventTypes.POINT_CHANGE
+        local pointLogEventData = SF.LootLog.GetEventDataTemplate(pointLogEventType)
+        pointLogEventData.member = self:GetFullIdentifier()
+        pointLogEventData.change = SF.LootLogPointChangeTypes.INCREMENT
+        pointLogEventData.amount = pointAmount
+        if metadata.reason ~= nil then
+            pointLogEventData.reason = tostring(metadata.reason)
         end
-        return false
+        if metadata.source ~= nil then
+            pointLogEventData.source = tostring(metadata.source)
+        end
+        if metadata.rollType ~= nil then
+            pointLogEventData.rollType = tostring(metadata.rollType)
+        end
+        if metadata.itemLink ~= nil then
+            pointLogEventData.itemLink = tostring(metadata.itemLink)
+        end
+
+        pointLogEntry = SF.LootLog.new(pointLogEventType, pointLogEventData, logOpts)
+        if not pointLogEntry then
+            if SF.Debug then
+                SF.Debug:Error("MEMBER", "Failed to create point clear log for %s", self:GetFullIdentifier())
+            end
+            return false
+        end
     end
 
     self.armor[slot] = false
-    self.pointBalance = self.pointBalance + pointAmount
+    if not skipPoints then
+        self.pointBalance = self.pointBalance + pointAmount
+    end
 
     AddLootLogToActiveProfile(armorLogEntry)
-    AddLootLogToActiveProfile(pointLogEntry)
+    if pointLogEntry then
+        AddLootLogToActiveProfile(pointLogEntry)
+    end
 
     if SF.Debug then
         SF.Debug:Info(
@@ -816,6 +954,7 @@ function Member:UpdateFromLootLog()
 
     -- Calculate point balance from POINT_CHANGE logs
     pointBalance = 0
+    local attendanceBalance = 0
     for _, log in ipairs(filteredLogs) do
         if log.eventType == SF.LootLogEventTypes.POINT_CHANGE then
             local amount = SF.LootLog.GetPointChangeAmount(log.eventData)
@@ -824,9 +963,20 @@ function Member:UpdateFromLootLog()
             elseif log.eventData.change == SF.LootLogPointChangeTypes.DECREMENT then
                 pointBalance = pointBalance - amount
             end
+        elseif log.eventType == SF.LootLogEventTypes.ATTENDANCE_CHANGE then
+            local amount = SF.LootLog.GetAttendanceChangeAmount(log.eventData)
+            if log.eventData.change == SF.LootLogPointChangeTypes.INCREMENT then
+                attendanceBalance = attendanceBalance + amount
+            elseif log.eventData.change == SF.LootLogPointChangeTypes.DECREMENT then
+                attendanceBalance = attendanceBalance - amount
+            end
         end
     end
+    if attendanceBalance < 0 then
+        attendanceBalance = 0
+    end
     self.pointBalance = pointBalance
+    self.attendanceBalance = attendanceBalance
     self.armor = armorStatuses
 end
 
@@ -848,6 +998,7 @@ function Member:ToTable()
         role = self.role,
         class = self.class,
         pointBalance = self.pointBalance,
+        attendanceBalance = tonumber(self.attendanceBalance) or 0,
         armor = armorCopy,
         most_recent_pre_raid_check_whisper = tonumber(self.most_recent_pre_raid_check_whisper) or nil,
         most_recent_raid_check_whisper = tonumber(self.most_recent_raid_check_whisper) or nil,
@@ -867,6 +1018,7 @@ function Member.FromTable(t)
     
     -- Set point balance
     m.pointBalance = tonumber(t.pointBalance) or 0
+    m.attendanceBalance = tonumber(t.attendanceBalance) or 0
     m.most_recent_pre_raid_check_whisper = tonumber(t.most_recent_pre_raid_check_whisper) or nil
     m.most_recent_raid_check_whisper = tonumber(t.most_recent_raid_check_whisper) or nil
     

--- a/SpectrumFederation/modules/LootHelper/Profiles.lua
+++ b/SpectrumFederation/modules/LootHelper/Profiles.lua
@@ -52,6 +52,46 @@ local RAID_CHECK_DEFAULTS = {
 	slots = RAID_CHECK_SLOT_DEFAULTS,
 }
 
+local LOOT_MODE_POINT_BASED = "point_based"
+local LOOT_MODE_REWARD_POT = "reward_pot"
+local DEDUCTION_TYPE_FLAT = "flat"
+local DEDUCTION_TYPE_PERCENT = "percent"
+
+local REWARD_POT_DEFAULTS = {
+	startingPotCopper = 0,
+	deductionType = DEDUCTION_TYPE_FLAT,
+	deductionValue = 0,
+}
+
+local function NormalizeLootMode(value)
+	if value == LOOT_MODE_REWARD_POT then
+		return LOOT_MODE_REWARD_POT
+	end
+	return LOOT_MODE_POINT_BASED
+end
+
+local function NormalizeDeductionType(value)
+	if value == DEDUCTION_TYPE_PERCENT then
+		return DEDUCTION_TYPE_PERCENT
+	end
+	return DEDUCTION_TYPE_FLAT
+end
+
+local function NormalizeNonNegativeNumber(value, defaultValue)
+	local amount = tonumber(value)
+	if amount == nil then
+		amount = tonumber(defaultValue) or 0
+	end
+	if amount < 0 then
+		amount = 0
+	end
+	return amount
+end
+
+local function NormalizeCopper(value)
+	return math.floor(NormalizeNonNegativeNumber(value, 0))
+end
+
 local function NormalizeRaidCheckPointsAward(value)
 	local amount = tonumber(value)
 	if amount == nil then
@@ -125,6 +165,16 @@ function LootProfile:_EnsureRaidCheckConfig()
 	cfg.pointsAwardPerRaidCheck = NormalizeRaidCheckPointsAward(cfg.pointsAwardPerRaidCheck)
 	cfg.checkGemsInSockets = cfg.checkGemsInSockets ~= false
 	cfg.requireMetaGem = cfg.requireMetaGem and true or false
+end
+
+function LootProfile:_EnsureRewardPotConfig()
+	self._lootMode = NormalizeLootMode(self._lootMode)
+	self._rewardPotStartingCopper = NormalizeCopper(self._rewardPotStartingCopper)
+	self._rewardPotDeductionType = NormalizeDeductionType(self._rewardPotDeductionType)
+	self._rewardPotDeductionValue = NormalizeNonNegativeNumber(self._rewardPotDeductionValue, REWARD_POT_DEFAULTS.deductionValue)
+	if self._rewardPotDeductionType == DEDUCTION_TYPE_FLAT then
+		self._rewardPotDeductionValue = math.floor(self._rewardPotDeductionValue)
+	end
 end
 
 function LootProfile:_EnsureRaidCheckEquipmentSnapshots()
@@ -440,6 +490,10 @@ function LootProfile.new(profileName)
     instance._raidWideSafeModeOnCombat = false
     instance._raidCheckConfig = CopyRaidCheckDefaults()
     instance._raidCheckEquipmentSnapshots = {}
+    instance._lootMode = LOOT_MODE_POINT_BASED
+    instance._rewardPotStartingCopper = REWARD_POT_DEFAULTS.startingPotCopper
+    instance._rewardPotDeductionType = REWARD_POT_DEFAULTS.deductionType
+    instance._rewardPotDeductionValue = REWARD_POT_DEFAULTS.deductionValue
     -- Create member instance for author
     local class = SF:GetPlayerClass()
     local adminRole = (SF.MemberRoles and SF.MemberRoles.ADMIN) or "admin"
@@ -685,6 +739,253 @@ function LootProfile:IsCurrentUserAdmin()
         end
     end
     return false
+end
+
+-- Function to check if the current user is the owner of this profile
+-- @return boolean isOwner
+function LootProfile:IsCurrentUserOwner()
+    local currentUser = SF:GetPlayerFullIdentifier()
+    if not currentUser then return false end
+    return self:IsOwner(currentUser)
+end
+
+-- Function to get the loot mode for this profile
+-- @return string lootMode
+function LootProfile:GetLootMode()
+    self:_EnsureRewardPotConfig()
+    return self._lootMode
+end
+
+-- Function to check whether Reward Pot mode is active
+-- @return boolean
+function LootProfile:IsRewardPotMode()
+    return self:GetLootMode() == LOOT_MODE_REWARD_POT
+end
+
+-- Function to check whether Point Based mode is active
+-- @return boolean
+function LootProfile:IsPointBasedMode()
+    return self:GetLootMode() == LOOT_MODE_POINT_BASED
+end
+
+-- Function to get Reward Pot configuration
+-- @return table
+function LootProfile:GetRewardPotConfig()
+    self:_EnsureRewardPotConfig()
+    return {
+        startingPotCopper = self._rewardPotStartingCopper,
+        deductionType = self._rewardPotDeductionType,
+        deductionValue = self._rewardPotDeductionValue,
+    }
+end
+
+-- Function to compute the current Reward Pot from starting amount plus logged deltas
+-- @return number copper
+function LootProfile:GetCurrentRewardPotCopper()
+    self:_EnsureRewardPotConfig()
+    local copper = self._rewardPotStartingCopper
+    local logs = self._lootLogs or {}
+    for i = 1, #logs do
+        local log = logs[i]
+        local eventType = (log.GetEventType and log:GetEventType()) or log._eventType
+        if eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.REWARD_POT_CHANGE) then
+            local data = (log.GetEventData and log:GetEventData()) or log._data or {}
+            local amount = (SF.LootLog and SF.LootLog.GetRewardPotChangeAmount and SF.LootLog.GetRewardPotChangeAmount(data)) or 0
+            if data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT) then
+                copper = copper + amount
+            elseif data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.DECREMENT) then
+                copper = copper - amount
+            end
+        end
+    end
+    if copper < 0 then
+        copper = 0
+    end
+    return copper
+end
+
+-- Function to compute a Raid Check pot deduction from the current pot
+-- @return number copper
+-- @return string|nil deductionType
+-- @return number|nil percent
+function LootProfile:ComputeRewardPotDeductionCopper()
+    self:_EnsureRewardPotConfig()
+    local current = self:GetCurrentRewardPotCopper()
+    if self._rewardPotDeductionType == DEDUCTION_TYPE_PERCENT then
+        local percent = tonumber(self._rewardPotDeductionValue) or 0
+        if percent <= 0 or current <= 0 then
+            return 0, DEDUCTION_TYPE_PERCENT, percent
+        end
+        local deducted = math.floor(current * percent / 100)
+        if deducted > current then
+            deducted = current
+        end
+        return deducted, DEDUCTION_TYPE_PERCENT, percent
+    end
+
+    local amount = math.floor(tonumber(self._rewardPotDeductionValue) or 0)
+    if amount > current then
+        amount = current
+    end
+    return amount, DEDUCTION_TYPE_FLAT, nil
+end
+
+local function AppendProfileLog(self, eventType, eventData, opts)
+    if not SF.LootLog then
+        return false, "Loot logs are unavailable."
+    end
+    local logEntry = SF.LootLog.new(eventType, eventData, opts)
+    if not logEntry then
+        return false, "Failed to create loot log entry."
+    end
+    if self.AddLootLog then
+        self:AddLootLog(logEntry)
+    end
+    return true, nil
+end
+
+-- Function to set loot mode. Owner only.
+-- @param string mode
+-- @return boolean success
+-- @return string|nil errorMessage
+function LootProfile:SetLootMode(mode)
+    self:_EnsureRewardPotConfig()
+    if not self:IsCurrentUserOwner() then
+        return false, "Only the profile owner can change loot mode."
+    end
+
+    mode = NormalizeLootMode(mode)
+    local oldMode = self._lootMode
+    if oldMode == mode then
+        return true, nil
+    end
+
+    local eventType = SF.LootLogEventTypes.LOOT_MODE_CHANGE
+    local eventData = SF.LootLog.GetEventDataTemplate(eventType)
+    eventData.oldMode = oldMode
+    eventData.newMode = mode
+    local ok, err = AppendProfileLog(self, eventType, eventData)
+    if not ok then
+        return false, err
+    end
+
+    self._lootMode = mode
+    if SF.Debug then
+        SF.Debug:Info("LootProfile", "Loot mode changed: %s -> %s", tostring(oldMode), tostring(mode))
+    end
+    return true, nil
+end
+
+-- Function to set Reward Pot configuration. Admin or owner.
+-- @param table cfg
+-- @return boolean success
+-- @return string|nil errorMessage
+function LootProfile:SetRewardPotConfig(cfg)
+    self:_EnsureRewardPotConfig()
+    if not self:IsCurrentUserAdmin() then
+        return false, "You must be an admin to change Reward Pot settings."
+    end
+
+    cfg = type(cfg) == "table" and cfg or {}
+    local startingPotCopper = cfg.startingPotCopper
+    if startingPotCopper == nil then
+        startingPotCopper = self._rewardPotStartingCopper
+    end
+    local deductionType = cfg.deductionType
+    if deductionType == nil then
+        deductionType = self._rewardPotDeductionType
+    end
+    local deductionValue = cfg.deductionValue
+    if deductionValue == nil then
+        deductionValue = self._rewardPotDeductionValue
+    end
+
+    startingPotCopper = NormalizeCopper(startingPotCopper)
+    deductionType = NormalizeDeductionType(deductionType)
+    deductionValue = NormalizeNonNegativeNumber(deductionValue, 0)
+    if deductionType == DEDUCTION_TYPE_FLAT then
+        deductionValue = math.floor(deductionValue)
+    end
+
+    if startingPotCopper == self._rewardPotStartingCopper
+        and deductionType == self._rewardPotDeductionType
+        and deductionValue == self._rewardPotDeductionValue then
+        return true, nil
+    end
+
+    local eventType = SF.LootLogEventTypes.REWARD_POT_CONFIG_CHANGE
+    local eventData = SF.LootLog.GetEventDataTemplate(eventType)
+    eventData.startingPotCopper = startingPotCopper
+    eventData.deductionType = deductionType
+    eventData.deductionValue = deductionValue
+    local ok, err = AppendProfileLog(self, eventType, eventData)
+    if not ok then
+        return false, err
+    end
+
+    self._rewardPotStartingCopper = startingPotCopper
+    self._rewardPotDeductionType = deductionType
+    self._rewardPotDeductionValue = deductionValue
+    return true, nil
+end
+
+-- Function to add or subtract gold from the Reward Pot. Admin or owner.
+-- Amount is clamped so the pot never goes below zero; the log stores the applied copper.
+-- @param string change INCREMENT or DECREMENT
+-- @param number amountCopper
+-- @param string|nil reason
+-- @param table|nil extra
+-- @return boolean success
+-- @return string|nil errorMessage
+function LootProfile:AdjustRewardPot(change, amountCopper, reason, extra)
+    self:_EnsureRewardPotConfig()
+    if not self:IsCurrentUserAdmin() then
+        return false, "You must be an admin to adjust the Reward Pot."
+    end
+
+    amountCopper = NormalizeCopper(amountCopper)
+    if amountCopper <= 0 then
+        return false, "Enter an amount greater than zero."
+    end
+
+    local increment = SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT or "INCREMENT"
+    local decrement = SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.DECREMENT or "DECREMENT"
+    if change ~= increment and change ~= decrement then
+        return false, "Invalid Reward Pot adjustment."
+    end
+
+    if change == decrement then
+        local current = self:GetCurrentRewardPotCopper()
+        if current <= 0 then
+            return false, "The Reward Pot is already empty."
+        end
+        if amountCopper > current then
+            amountCopper = current
+        end
+    end
+
+    local eventType = SF.LootLogEventTypes.REWARD_POT_CHANGE
+    local eventData = SF.LootLog.GetEventDataTemplate(eventType)
+    eventData.change = change
+    eventData.amount = amountCopper
+    eventData.reason = reason or "MANUAL"
+    extra = type(extra) == "table" and extra or nil
+    if extra and extra.deductionType then
+        eventData.deductionType = extra.deductionType
+    end
+    if extra and extra.percent ~= nil then
+        eventData.percent = extra.percent
+    end
+
+    local logOpts = {}
+    if extra and extra.logAuthor then
+        logOpts.author = extra.logAuthor
+    end
+    local ok, err = AppendProfileLog(self, eventType, eventData, logOpts)
+    if not ok then
+        return false, err
+    end
+    return true, nil
 end
 
 -- Function to get the point name for this profile
@@ -1689,6 +1990,8 @@ function LootProfile:ExportSnapshot()
 		equipmentSnapshots = equipmentSnapshotsOut,
 		pointName       = self._pointName or "Points",
 		raidCheck       = self:GetRaidCheckConfig(),
+		lootMode        = self:GetLootMode(),
+		rewardPot       = self:GetRewardPotConfig(),
 	}
 end
 
@@ -1774,6 +2077,27 @@ function LootProfile.ValidateSnapshot(snapshot)
 		end
 		if snapshot.raidCheck.slots ~= nil and type(snapshot.raidCheck.slots) ~= "table" then
 			return false, "snapshot.raidCheck.slots must be a table when provided"
+		end
+	end
+
+	if snapshot.lootMode ~= nil then
+		if type(snapshot.lootMode) ~= "string" then
+			return false, "snapshot.lootMode must be a string when provided"
+		end
+	end
+
+	if snapshot.rewardPot ~= nil then
+		if type(snapshot.rewardPot) ~= "table" then
+			return false, "snapshot.rewardPot must be a table or nil"
+		end
+		if snapshot.rewardPot.startingPotCopper ~= nil and type(snapshot.rewardPot.startingPotCopper) ~= "number" then
+			return false, "snapshot.rewardPot.startingPotCopper must be a number when provided"
+		end
+		if snapshot.rewardPot.deductionType ~= nil and type(snapshot.rewardPot.deductionType) ~= "string" then
+			return false, "snapshot.rewardPot.deductionType must be a string when provided"
+		end
+		if snapshot.rewardPot.deductionValue ~= nil and type(snapshot.rewardPot.deductionValue) ~= "number" then
+			return false, "snapshot.rewardPot.deductionValue must be a number when provided"
 		end
 	end
 
@@ -1906,6 +2230,28 @@ function LootProfile:ImportSnapshot(snapshot, opts)
 	end
 
 	self:_EnsureRaidCheckConfig()
+	self:_EnsureRewardPotConfig()
+
+	-- Import loot mode / Reward Pot config only when the snapshot actually contains them.
+	-- Older clients omit these fields; keeping local values prevents clobbering.
+	if type(snapshot.lootMode) == "string" then
+		self._lootMode = NormalizeLootMode(snapshot.lootMode)
+	end
+	if type(snapshot.rewardPot) == "table" then
+		if snapshot.rewardPot.startingPotCopper ~= nil then
+			self._rewardPotStartingCopper = NormalizeCopper(snapshot.rewardPot.startingPotCopper)
+		end
+		if snapshot.rewardPot.deductionType ~= nil then
+			self._rewardPotDeductionType = NormalizeDeductionType(snapshot.rewardPot.deductionType)
+		end
+		if snapshot.rewardPot.deductionValue ~= nil then
+			self._rewardPotDeductionValue = NormalizeNonNegativeNumber(snapshot.rewardPot.deductionValue, 0)
+			if self._rewardPotDeductionType == DEDUCTION_TYPE_FLAT then
+				self._rewardPotDeductionValue = math.floor(self._rewardPotDeductionValue)
+			end
+		end
+	end
+	self:_EnsureRewardPotConfig()
 
 	-- Merge Logs
 	local inserted = self:MergeLogTables(snapshot.lootLogs, opts)
@@ -2051,3 +2397,11 @@ end
 -- Export to Namespace
 -- ========================================================================
 SF.LootProfile = LootProfile
+SF.LootModes = {
+	POINT_BASED = LOOT_MODE_POINT_BASED,
+	REWARD_POT = LOOT_MODE_REWARD_POT,
+}
+SF.RewardPotDeductionTypes = {
+	FLAT = DEDUCTION_TYPE_FLAT,
+	PERCENT = DEDUCTION_TYPE_PERCENT,
+}

--- a/SpectrumFederation/modules/LootHelperSync/12_LiveUpdates.lua
+++ b/SpectrumFederation/modules/LootHelperSync/12_LiveUpdates.lua
@@ -119,6 +119,16 @@ function Sync:HandleNewLog(sender, payload)
             return
         end
     end
+
+    local eventType = logTable._eventType or logTable.eventType
+    if eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.LOOT_MODE_CHANGE) then
+        if not (profile.IsOwner and profile:IsOwner(sender)) then
+            if SF.PrintWarning then
+                SF:PrintWarning(("Ignoring loot mode change from %s for profile %s: not the owner."):format(tostring(sender), tostring(profileId)))
+            end
+            return
+        end
+    end
     
     -- Dedupe by logId
     local logId = self:_ExtractLogId(logTable)

--- a/SpectrumFederation/modules/LootHelperSync/16_ProfileIntegration.lua
+++ b/SpectrumFederation/modules/LootHelperSync/16_ProfileIntegration.lua
@@ -23,6 +23,7 @@ end
 local function _ResetMemberState(member)
     if not member then return end
     member.pointBalance = 0
+    member.attendanceBalance = 0
     member.armor = _BuildEmptyArmor()
     if not member.role and SF.MemberRoles then
         member.role = SF.MemberRoles.MEMBER
@@ -372,6 +373,14 @@ function Sync:RebuildProfile(profileId, reason)
 	if profile._EnsureRaidCheckConfig then
 		profile:_EnsureRaidCheckConfig()
 	end
+	if profile._EnsureRewardPotConfig then
+		profile:_EnsureRewardPotConfig()
+	end
+
+	local lootMode = profile._lootMode
+	local startingPotCopper = tonumber(profile._rewardPotStartingCopper) or 0
+	local deductionType = profile._rewardPotDeductionType
+	local deductionValue = tonumber(profile._rewardPotDeductionValue) or 0
 
 	local rebuildReason = tostring(reason or "unknown")
 	local logs = profile.GetLootLogs and profile:GetLootLogs() or profile._lootLogs or {}
@@ -470,6 +479,36 @@ function Sync:RebuildProfile(profileId, reason)
                         rebuildReason, tostring(_MemberId(member) or data.member), tostring(oldPoints or 0), tostring(newPoints - oldPoints),
                         tostring(newPoints), tostring(data.change))
                 end
+            elseif eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.ATTENDANCE_CHANGE) then
+                local member = ensureMember(data.member)
+                local amount = (SF.LootLog and SF.LootLog.GetAttendanceChangeAmount and SF.LootLog.GetAttendanceChangeAmount(data)) or 1
+                if member then
+                    member.attendanceBalance = tonumber(member.attendanceBalance) or 0
+                    if data.change == SF.LootLogPointChangeTypes.INCREMENT then
+                        member.attendanceBalance = member.attendanceBalance + amount
+                    elseif data.change == SF.LootLogPointChangeTypes.DECREMENT then
+                        member.attendanceBalance = member.attendanceBalance - amount
+                    end
+                    if member.attendanceBalance < 0 then
+                        member.attendanceBalance = 0
+                    end
+                end
+            elseif eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.LOOT_MODE_CHANGE) then
+                if type(data.newMode) == "string" then
+                    lootMode = data.newMode
+                end
+            elseif eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.REWARD_POT_CONFIG_CHANGE) then
+                if data.startingPotCopper ~= nil then
+                    startingPotCopper = math.floor(tonumber(data.startingPotCopper) or 0)
+                    if startingPotCopper < 0 then startingPotCopper = 0 end
+                end
+                if type(data.deductionType) == "string" then
+                    deductionType = data.deductionType
+                end
+                if data.deductionValue ~= nil then
+                    deductionValue = tonumber(data.deductionValue) or 0
+                    if deductionValue < 0 then deductionValue = 0 end
+                end
             elseif eventType == (SF.LootLogEventTypes and SF.LootLogEventTypes.ARMOR_CHANGE) then
                 local member = ensureMember(data.member)
                 if member and data.slot then
@@ -528,6 +567,14 @@ function Sync:RebuildProfile(profileId, reason)
 
     if profile._EnsureOwnerIsAdmin then
         profile:_EnsureOwnerIsAdmin()
+    end
+
+    profile._lootMode = lootMode
+    profile._rewardPotStartingCopper = startingPotCopper
+    profile._rewardPotDeductionType = deductionType
+    profile._rewardPotDeductionValue = deductionValue
+    if profile._EnsureRewardPotConfig then
+        profile:_EnsureRewardPotConfig()
     end
 
     if SF.Debug then

--- a/SpectrumFederation/modules/RaidCheck.lua
+++ b/SpectrumFederation/modules/RaidCheck.lua
@@ -16,6 +16,7 @@ local RC = SF.RaidCheck
 
 local RAID_CHECK_REASON = "RAID_CHECK"
 local RAID_CHECK_POINT_AWARD_DEFAULT = 0.5
+local ATTENDANCE_POINT_NAME = "Attendance Point"
 local META_GEM_QUALITY = 4
 local MAX_GEM_SOCKETS_TO_SCAN = 8
 local INSPECT_CACHE_TTL_SECONDS = 30 -- Background recheck cadence for live inspect data.
@@ -2637,6 +2638,10 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 	end
 
 	local rewardPot = profile.IsRewardPotMode and profile:IsRewardPotMode()
+	local whisperPointName = pointName
+	if rewardPot then
+		whisperPointName = ATTENDANCE_POINT_NAME
+	end
 
 	local function MarkUnprepared(reason, noInspectData)
 		result.unprepared = true
@@ -2662,7 +2667,7 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 		local list = FormatMissingList(missing)
 		local alreadyWhispered = HasBeenWhisperedToday(member, mode)
 		if whisper and not alreadyWhispered then
-			WhisperMissing(whisperTarget, cfg, unitInfo.short, pointName, list, mode)
+			WhisperMissing(whisperTarget, cfg, unitInfo.short, whisperPointName, list, mode)
 			result.whisperedMissing = true
 			MarkWhisperSent(member, mode, time())
 		elseif whisper and alreadyWhispered then
@@ -2689,10 +2694,8 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 			awarded = AwardPrepared(profile, member, pointName, pointAward)
 		end
 		if awarded and whisper and ShouldWhisperPrepared(cfg) then
-			local whisperPointName = pointName
 			local whisperAward = pointAward
 			if rewardPot then
-				whisperPointName = "Attendance Point"
 				whisperAward = 1
 			end
 			WhisperPrepared(whisperTarget, cfg, unitInfo.short, whisperPointName, whisperAward)

--- a/SpectrumFederation/modules/RaidCheck.lua
+++ b/SpectrumFederation/modules/RaidCheck.lua
@@ -2617,10 +2617,7 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 	local inspectState = RC:_GetTroubleshootingInspectState(unitInfo.unit, unitInfo)
 	local whisper = ShouldWhisper(mode, cfg)
 	local whisperTarget = unitInfo.id or unitInfo.short
-	local member = nil
-	if whisper or mode == "raid" then
-		member = FindMember(profile, unitInfo.id)
-	end
+	local member = FindMember(profile, unitInfo.id)
 	local result = {
 		name = unitInfo.short,
 		displayName = unitInfo.displayName or unitInfo.short,
@@ -2629,27 +2626,36 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 		inspectPending = nil,
 		whisperedMissing = false,
 		alreadyWhispered = false,
+		prepared = false,
+		unprepared = false,
+		noInspectData = false,
 	}
 
-	if type(inspectState) ~= "table" then
-		result.inspectPending = "Unavailable"
+	if not member then
+		result.skippedAward = true
 		return result
+	end
+
+	local rewardPot = profile.IsRewardPotMode and profile:IsRewardPotMode()
+
+	local function MarkUnprepared(reason, noInspectData)
+		result.unprepared = true
+		result.missing = reason
+		result.noInspectData = noInspectData and true or false
+		return result
+	end
+
+	if type(inspectState) ~= "table" then
+		return MarkUnprepared("No inspect data", true)
 	end
 
 	if not (inspectState.isKnown and HasEquipmentData(inspectState.slotsByInventory)) then
-		result.inspectPending = inspectState and (inspectState.label or inspectState.status) or "Loading"
-		return result
+		return MarkUnprepared(inspectState.message or inspectState.label or inspectState.status or "No inspect data", true)
 	end
 
 	local missing, hasItemDataPending = EvaluateSnapshot(inspectState.slotsByInventory, cfg)
-
-	-- If any tracked slot still has incomplete item data (texture/itemId present
-	-- but link unavailable), treat the player as pending rather than definitively
-	-- missing requirements.  This prevents false-positive whispers and raid check
-	-- failures caused by partially-loaded item data.
 	if hasItemDataPending then
-		result.inspectPending = "Item data loading"
-		return result
+		return MarkUnprepared("Item data incomplete", true)
 	end
 
 	if #missing > 0 then
@@ -2662,19 +2668,34 @@ local function RunForUnit(unitInfo, profile, cfg, mode, pointName, pointAward)
 		elseif whisper and alreadyWhispered then
 			result.alreadyWhispered = true
 		end
+		result.unprepared = true
 		result.missing = list
 		return result
 	end
 
-	if mode == "raid" then
-		if not member then
-			result.skippedAward = true
-			return result
-		end
+	result.prepared = true
 
-		local awarded = AwardPrepared(profile, member, pointName, pointAward)
+	if mode == "raid" then
+		local awarded = false
+		if rewardPot then
+			if member.IncrementAttendance then
+				awarded = member:IncrementAttendance({
+					amount = 1,
+					logAuthor = "Raid Check",
+					reason = RAID_CHECK_REASON,
+				})
+			end
+		else
+			awarded = AwardPrepared(profile, member, pointName, pointAward)
+		end
 		if awarded and whisper and ShouldWhisperPrepared(cfg) then
-			WhisperPrepared(whisperTarget, cfg, unitInfo.short, pointName, pointAward)
+			local whisperPointName = pointName
+			local whisperAward = pointAward
+			if rewardPot then
+				whisperPointName = "Attendance Point"
+				whisperAward = 1
+			end
+			WhisperPrepared(whisperTarget, cfg, unitInfo.short, whisperPointName, whisperAward)
 		end
 	end
 
@@ -2698,7 +2719,7 @@ function RC:RunPreRaidCheck()
 
 	for _, unit in ipairs(CollectUnits()) do
 		local info = BuildUnitInfo(unit)
-		if info.id then
+		if info.id and FindMember(profile, info.id) then
 			local res = RunForUnit(info, profile, cfg, "pre", GetPointName(profile))
 			if res then
 				if res.missing then
@@ -2735,12 +2756,16 @@ function RC:RunRaidCheck()
 	local summaryMissing = {}
 	local summaryPending = {}
 	local summarySkippedAward = {}
+	local anyUnprepared = false
 
 	for _, unit in ipairs(CollectUnits()) do
 		local info = BuildUnitInfo(unit)
-		if info.id then
+		if info.id and FindMember(profile, info.id) then
 			local res = RunForUnit(info, profile, cfg, "raid", pointName, pointAward)
 			if res then
+				if res.unprepared or res.missing then
+					anyUnprepared = true
+				end
 				if res.missing then
 					table.insert(summaryMissing, res)
 				elseif res.inspectPending then
@@ -2748,6 +2773,27 @@ function RC:RunRaidCheck()
 				elseif res.skippedAward then
 					table.insert(summarySkippedAward, res)
 				end
+			end
+		end
+	end
+
+	if profile.IsRewardPotMode and profile:IsRewardPotMode() and anyUnprepared and profile.AdjustRewardPot then
+		local amount, deductionType, percent = profile:ComputeRewardPotDeductionCopper()
+		if amount and amount > 0 then
+			local ok, err = profile:AdjustRewardPot(
+				SF.LootLogPointChangeTypes.DECREMENT,
+				amount,
+				"RAID_DEDUCTION",
+				{
+					logAuthor = "Raid Check",
+					deductionType = deductionType,
+					percent = percent,
+				}
+			)
+			if ok then
+				EmitAdminMessage(("[Raid Check] Reward Pot deducted %s."):format(SF.FormatMoney and SF.FormatMoney(amount) or tostring(amount)))
+			elseif err then
+				SF:PrintWarning(err)
 			end
 		end
 	end

--- a/SpectrumFederation/modules/UI/LootHelper/Constants.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/Constants.lua
@@ -11,6 +11,7 @@ LH.Constants = LH.Constants or {
     TITLE_HEIGHT = 28,
     TITLE_PADDING_X = 10,
     CONTENT_PADDING = 10,
+    POT_HEADER_HEIGHT = 22,
 
     -- Default placement
     DEFAULT_POINT = "CENTER",

--- a/SpectrumFederation/modules/UI/LootHelper/Controller.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/Controller.lua
@@ -339,6 +339,8 @@ function Controller:RefreshTitle()
     local primaryTitle = "Points"
     local pointName = ""
     local canAdmin = false
+    local rewardPot = false
+    local potText = nil
 
     if SF.GetActiveProfile then
         local p = SF:GetActiveProfile()
@@ -347,12 +349,25 @@ function Controller:RefreshTitle()
             canAdmin = p:IsCurrentUserAdmin() and true or false
            end
 
-           primaryTitle = "Points"
-           if p.GetPointName then
-            local v = p:GetPointName()
-            v = tostring(v or ""):match("^%s*(.-)%s*$")  -- trim
-            if v ~= "" then
-                primaryTitle = v
+           rewardPot = p.IsRewardPotMode and p:IsRewardPotMode() and true or false
+           if rewardPot then
+            primaryTitle = "Attendance"
+            if p.GetCurrentRewardPotCopper then
+                local copper = p:GetCurrentRewardPotCopper() or 0
+                if SF.FormatMoney then
+                    potText = "Reward Pot: " .. SF.FormatMoney(copper)
+                else
+                    potText = "Reward Pot: " .. tostring(copper)
+                end
+            end
+           else
+            primaryTitle = "Points"
+            if p.GetPointName then
+                local v = p:GetPointName()
+                v = tostring(v or ""):match("^%s*(.-)%s*$")  -- trim
+                if v ~= "" then
+                    primaryTitle = v
+                end
             end
            end
         end
@@ -361,6 +376,9 @@ function Controller:RefreshTitle()
     if LH.Window then
         LH.Window:SetProfileName(primaryTitle)
         LH.Window:SetPointName(pointName)
+        if LH.Window.SetRewardPotHeader then
+            LH.Window:SetRewardPotHeader(rewardPot, potText)
+        end
         LH.Window:SetPlayButtonVisible(canAdmin)
         LH.Window:SetSessionActive(IsSessionActive())
     end

--- a/SpectrumFederation/modules/UI/LootHelper/RosterModel.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/RosterModel.lua
@@ -222,6 +222,7 @@ function Model:Build(profile)
     if profile.IsCurrentUserAdmin then
         canAdmin = profile:IsCurrentUserAdmin() and true or false
     end
+    local rewardPot = profile.IsRewardPotMode and profile:IsRewardPotMode() and true or false
 
     local raidById = BuildRaidMap()
     for id, info in pairs(raidById) do
@@ -239,7 +240,12 @@ function Model:Build(profile)
 
         if showMembersNotInRaid or inRaid then
             local m = entry.member
-            local points = (m and m.GetPointBalance and m:GetPointBalance()) or m.pointBalance or 0
+            local points = 0
+            if rewardPot then
+                points = (m and m.GetAttendanceBalance and m:GetAttendanceBalance()) or (m and m.attendanceBalance) or 0
+            else
+                points = (m and m.GetPointBalance and m:GetPointBalance()) or (m and m.pointBalance) or 0
+            end
             local resolvedClass = (raidInfo and raidInfo.class) or entry.class or self._classByMemberId[id] or "UNKNOWN"
             if resolvedClass == "UNKNOWN" and SF.Debug then
                 SF.Debug:Warn("LH_ICON", "Unable to resolve class metadata (member=%s classRaw=%s inRaid=%s)",
@@ -260,6 +266,7 @@ function Model:Build(profile)
                 member = m,
                 canAdmin = canAdmin,
                 inRaid = inRaid,
+                rewardPot = rewardPot,
             })
         end
     end

--- a/SpectrumFederation/modules/UI/LootHelper/RosterView.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/RosterView.lua
@@ -15,6 +15,7 @@ local BTN_SIZE = 20
 local BTN_GAP = 3
 local POINTS_WIDTH = 32
 local MANUAL_POINT_STEP = 0.5
+local MANUAL_ATTENDANCE_STEP = 1
 
 -- Cropping presets you can tweak quickly:
 local CROP_ICON   = 0.07  -- great for Interface\Icons\
@@ -462,7 +463,15 @@ function View:_BindRowActions(r, model)
         -- Up/Down buttons (admin only)
         if model.canAdmin and model.member then
             r.BtnUp:SetScript("OnClick", function()
-                if model.member.IncrementPoints then
+                if model.rewardPot then
+                    if model.member.IncrementAttendance then
+                        pcall(function()
+                            model.member:IncrementAttendance({
+                                amount = MANUAL_ATTENDANCE_STEP,
+                            })
+                        end)
+                    end
+                elseif model.member.IncrementPoints then
                     pcall(function()
                         model.member:IncrementPoints({
                             amount = MANUAL_POINT_STEP,
@@ -471,12 +480,20 @@ function View:_BindRowActions(r, model)
                 end
                 -- DATA_CHANGED event is automatically fired via Events.lua hook
                 if SF.Debug then
-                    SF.Debug:Info("LH_ROSTER_VIEW", "IncrementPoints: %s", tostring(model.memberId))
+                    SF.Debug:Info("LH_ROSTER_VIEW", "%s: %s", model.rewardPot and "IncrementAttendance" or "IncrementPoints", tostring(model.memberId))
                 end
             end)
             
             r.BtnDown:SetScript("OnClick", function()
-                if model.member.DecrementPoints then
+                if model.rewardPot then
+                    if model.member.DecrementAttendance then
+                        pcall(function()
+                            model.member:DecrementAttendance({
+                                amount = MANUAL_ATTENDANCE_STEP,
+                            })
+                        end)
+                    end
+                elseif model.member.DecrementPoints then
                     pcall(function()
                         model.member:DecrementPoints({
                             amount = MANUAL_POINT_STEP,
@@ -485,7 +502,7 @@ function View:_BindRowActions(r, model)
                 end
                 -- DATA_CHANGED event is automatically fired via Events.lua hook
                 if SF.Debug then
-                    SF.Debug:Info("LH_ROSTER_VIEW", "DecrementPoints: %s", tostring(model.memberId))
+                    SF.Debug:Info("LH_ROSTER_VIEW", "%s: %s", model.rewardPot and "DecrementAttendance" or "DecrementPoints", tostring(model.memberId))
                 end
             end)
         end

--- a/SpectrumFederation/modules/UI/LootHelper/Style.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/Style.lua
@@ -56,6 +56,9 @@ function Style:Apply(frame)
     if frame.Title and frame.Title.Session and frame.Title.Session.SetFont then
         frame.Title.Session:SetFont(fontPath, math.max(8, fontSize - 1), "OUTLINE")
     end
+    if frame.Content and frame.Content.PotHeader and frame.Content.PotHeader.Text and frame.Content.PotHeader.Text.SetFont then
+        frame.Content.PotHeader.Text:SetFont(fontPath, fontSize, "")
+    end
 
     -- Placeholder hook
     if frame.Content and frame.Content.Placeholder and frame.Content.Placeholder.SetFont then

--- a/SpectrumFederation/modules/UI/LootHelper/Window.lua
+++ b/SpectrumFederation/modules/UI/LootHelper/Window.lua
@@ -568,6 +568,22 @@ function Window:Create()
     content:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -C.CONTENT_PADDING, C.CONTENT_PADDING)
     frame.Content = content
 
+    local potHeader = CreateFrame("Frame", nil, content)
+    potHeader:SetHeight(C.POT_HEADER_HEIGHT or 22)
+    potHeader:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+    potHeader:SetPoint("TOPRIGHT", content, "TOPRIGHT", 0, 0)
+    potHeader:Hide()
+    content.PotHeader = potHeader
+
+    local potText = potHeader:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+    potText:SetPoint("LEFT", potHeader, "LEFT", 4, 0)
+    potText:SetPoint("RIGHT", potHeader, "RIGHT", -4, 0)
+    potText:SetJustifyH("LEFT")
+    potText:SetWordWrap(false)
+    potText:SetMaxLines(1)
+    potText:SetText("")
+    potHeader.Text = potText
+
     local scroll = CreateFrame("ScrollFrame", nil, content, "UIPanelScrollFrameTemplate")
     scroll:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
     local sb = scroll.ScrollBar
@@ -682,6 +698,23 @@ function Window:SetPointName(name)
     end
 end
 
+function Window:SetRewardPotHeader(isVisible, text)
+    local f = self._frame
+    if not f or not f.Content or not f.Content.PotHeader then return end
+
+    local header = f.Content.PotHeader
+    isVisible = isVisible and true or false
+    header:SetShown(isVisible)
+    if header.Text then
+        if isVisible then
+            header.Text:SetText(tostring(text or ""))
+        else
+            header.Text:SetText("")
+        end
+    end
+    self:RequestScrollInsetsUpdate()
+end
+
 function Window:SetPlayButtonVisible(isVisible)
     local f = self._frame
     if not f or not f.Title or not f.Title.Play then return end
@@ -789,9 +822,16 @@ function Window:UpdateScrollInsets()
 		bottomInset = h + (C.RESIZE_HANDLE_GAP or 6)
 	end
 
+	-- Reserve top inset if the Reward Pot header is shown
+	local topInset = 0
+	local potHeader = content.PotHeader
+	if potHeader and potHeader:IsShown() then
+		topInset = potHeader:GetHeight() or (C.POT_HEADER_HEIGHT or 22)
+	end
+
 	-- Apply anchors
 	scroll:ClearAllPoints()
-	scroll:SetPoint("TOPLEFT", content, "TOPLEFT", 0, 0)
+	scroll:SetPoint("TOPLEFT", content, "TOPLEFT", 0, -topInset)
 	scroll:SetPoint("BOTTOMRIGHT", content, "BOTTOMRIGHT", -rightInset, bottomInset)
 
 	-- Clamp scroll offset if content shrank while scrolled

--- a/SpectrumFederation/modules/UI/Settings/Control/Controls.lua
+++ b/SpectrumFederation/modules/UI/Settings/Control/Controls.lua
@@ -14,6 +14,7 @@ local LABEL_WIDTH   = R.labelWidth or 220
 local GUTTER        = R.gutter or 16
 local CONTROL_WIDTH = R.controlWidth or 240
 local ADMIN_ONLY_SUFFIX = "|cffff4040(Admin Only)|r"
+local OWNER_ONLY_SUFFIX = "|cffff4040(Owner Only)|r"
 
 -- Evaluate a value or thunk to a boolean with default
 -- @param v any Boolean, function returning boolean, or nil
@@ -64,24 +65,47 @@ local function IsAdminForSection(section)
 	return result and true or false
 end
 
+local function IsOwnerForSection(section)
+	local predicate = section and section.__sfOwnerPredicate
+	if type(predicate) ~= "function" then
+		return true
+	end
+
+	local ok, result = pcall(predicate)
+	if not ok then
+		return true
+	end
+
+	return result and true or false
+end
+
 local function EvalEnabled(section, opts)
 	opts = opts or {}
 	local enabled = EvalBool(opts.enabled, true)
 	if opts.adminOnly then
 		enabled = enabled and IsAdminForSection(section)
 	end
+	if opts.ownerOnly then
+		enabled = enabled and IsOwnerForSection(section)
+	end
 	return enabled
 end
 
-local function FormatTooltipTitle(title, adminOnly)
+local function FormatTooltipTitle(title, adminOnly, ownerOnly)
 	title = title or ""
-	if not adminOnly then
+	local suffix
+	if ownerOnly then
+		suffix = OWNER_ONLY_SUFFIX
+	elseif adminOnly then
+		suffix = ADMIN_ONLY_SUFFIX
+	end
+	if not suffix then
 		return title
 	end
 	if title ~= "" then
-		return string.format("%s %s", title, ADMIN_ONLY_SUFFIX)
+		return string.format("%s %s", title, suffix)
 	end
-	return ADMIN_ONLY_SUFFIX
+	return suffix
 end
 
 local function HasAdminOnlyItems(items)
@@ -196,13 +220,13 @@ end
 -- @param title string|nil Tooltip title
 -- @param text string|nil Tooltip body text
 -- @return nil
-local function AttachTooltip(region, title, text, adminOnly)
+local function AttachTooltip(region, title, text, adminOnly, ownerOnly)
 	if not text or text == "" then return end
 	region:EnableMouse(true)
 
 	region:SetScript("OnEnter", function(self)
 		GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-		GameTooltip:SetText(FormatTooltipTitle(title, adminOnly), 1, 1, 1)
+		GameTooltip:SetText(FormatTooltipTitle(title, adminOnly, ownerOnly), 1, 1, 1)
 		GameTooltip:AddLine(text, nil, nil, nil, true)
 		GameTooltip:Show()
 	end)
@@ -374,7 +398,7 @@ end
 				end)
 
 				if def.tooltip then
-					AttachTooltip(dropdown, def.defaultText or "", def.tooltip, def.adminOnly or opts.adminOnly)
+					AttachTooltip(dropdown, def.defaultText or "", def.tooltip, def.adminOnly or opts.adminOnly, def.ownerOnly or opts.ownerOnly)
 				end
 
 				widgets[#widgets + 1] = dropdown
@@ -400,7 +424,7 @@ end
 				end)
 
 				if def.tooltip then
-					AttachTooltip(button, def.buttonText or def.text or "", def.tooltip, def.adminOnly or opts.adminOnly)
+					AttachTooltip(button, def.buttonText or def.text or "", def.tooltip, def.adminOnly or opts.adminOnly, def.ownerOnly or opts.ownerOnly)
 				end
 
 				widgets[#widgets + 1] = button
@@ -468,7 +492,7 @@ function Controls:AddCheckboxRow(section, opts)
 			label:SetText(def.label or "")
 
 			if def.tooltip then
-				AttachTooltip(label, def.label, def.tooltip, def.adminOnly or rowOpts.adminOnly)
+				AttachTooltip(label, def.label, def.tooltip, def.adminOnly or rowOpts.adminOnly, def.ownerOnly or rowOpts.ownerOnly)
 			end
 
 			cb:SetScript("OnClick", function(selfBtn)
@@ -544,7 +568,7 @@ function Controls:InitRow(row, opts)
 	control:SetPoint("TOP", row, "TOP", 0, 0)
 	control:SetPoint("BOTTOM", row, "BOTTOM", 0, 0)
 
-	AttachTooltip(row, opts.label, opts.tooltip, opts.adminOnly)
+	AttachTooltip(row, opts.label, opts.tooltip, opts.adminOnly, opts.ownerOnly)
 	return label, control
 end
 
@@ -645,7 +669,7 @@ function Controls:AddCheckboxGrid(section, opts)
 			label:SetText(def.label or "")
 
 			if def.tooltip then
-				AttachTooltip(cell, def.label, def.tooltip, def.adminOnly or rowOpts.adminOnly)
+				AttachTooltip(cell, def.label, def.tooltip, def.adminOnly or rowOpts.adminOnly, def.ownerOnly or rowOpts.ownerOnly)
 			end
 
 			cb:SetScript("OnClick", function(selfBtn)
@@ -1052,6 +1076,93 @@ function Controls:AddEditBox(section, opts)
 	end)
 end
 
+-- Add gold/silver/copper money editors bound to a copper getter/setter.
+-- @param section table Section to add row into
+-- @param opts table Options including get/set copper
+-- @return Frame The created row
+function Controls:AddMoneyEdit(section, opts)
+	local get, set = ResolveGetSet(opts)
+
+	return section:AddRow(26, function(row)
+		local _, control = self:InitRow(row, opts)
+		local boxes = {}
+		local ignore = false
+
+		local function MakeBox(parent, width)
+			local edit = CreateFrame("EditBox", nil, parent, "InputBoxTemplate")
+			edit:SetAutoFocus(false)
+			edit:SetSize(width, 22)
+			edit:SetNumeric(true)
+			edit:SetMaxLetters(8)
+			edit:SetTextColor(1, 1, 1)
+			return edit
+		end
+
+		local goldBox = MakeBox(control, 70)
+		goldBox:SetPoint("LEFT", control, "LEFT", 0, 0)
+		local goldLabel = control:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+		goldLabel:SetPoint("LEFT", goldBox, "RIGHT", 4, 0)
+		goldLabel:SetText("g")
+
+		local silverBox = MakeBox(control, 44)
+		silverBox:SetPoint("LEFT", goldLabel, "RIGHT", 8, 0)
+		local silverLabel = control:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+		silverLabel:SetPoint("LEFT", silverBox, "RIGHT", 4, 0)
+		silverLabel:SetText("s")
+
+		local copperBox = MakeBox(control, 44)
+		copperBox:SetPoint("LEFT", silverLabel, "RIGHT", 8, 0)
+		local copperLabel = control:CreateFontString(nil, "ARTWORK", "GameFontHighlightSmall")
+		copperLabel:SetPoint("LEFT", copperBox, "RIGHT", 4, 0)
+		copperLabel:SetText("c")
+
+		boxes[1] = goldBox
+		boxes[2] = silverBox
+		boxes[3] = copperBox
+
+		local function Commit()
+			if ignore then return end
+			if goldBox.IsEnabled and not goldBox:IsEnabled() then return end
+			local copper = SF.MoneyFromCoins(goldBox:GetText(), silverBox:GetText(), copperBox:GetText())
+			set(copper)
+			if opts.onCommit then
+				opts.onCommit(copper)
+			end
+		end
+
+		local function RefreshFromValue()
+			ignore = true
+			local gold, silver, remain = SF.MoneyToCoins(get() or 0)
+			goldBox:SetText(tostring(gold))
+			silverBox:SetText(tostring(silver))
+			copperBox:SetText(tostring(remain))
+			ignore = false
+		end
+
+		for i = 1, #boxes do
+			boxes[i]:SetScript("OnEnterPressed", function(selfEdit)
+				Commit()
+				selfEdit:ClearFocus()
+			end)
+			boxes[i]:SetScript("OnEditFocusLost", function()
+				Commit()
+			end)
+		end
+
+		local function Refresh()
+			RefreshFromValue()
+			local _, enabled = self:_ApplyRowState(row, section, opts, boxes)
+			local c = enabled and 1 or 0.6
+			for i = 1, #boxes do
+				boxes[i]:SetTextColor(c, c, c)
+			end
+		end
+
+		Refresh()
+		RegisterRefresh(section, Refresh)
+	end)
+end
+
 -- Add a dropdown with an adjacent icon button
 -- @param section table Section to add row into
 -- @param opts table Options including label, options, iconAtlas, iconTooltip, onIconClick
@@ -1074,7 +1185,7 @@ function Controls:AddDropdownWithIconButton(section, opts)
 
 		local iconTooltip = opts.iconTooltip or opts.iconToolTip
 		if iconTooltip then
-			AttachTooltip(iconBtn, opts.label or "", iconTooltip, opts.adminOnly)
+			AttachTooltip(iconBtn, opts.label or "", iconTooltip, opts.adminOnly, opts.ownerOnly)
 		end
 
 		local function GetOptions()

--- a/SpectrumFederation/modules/UI/Settings/DefinitionRenderer.lua
+++ b/SpectrumFederation/modules/UI/Settings/DefinitionRenderer.lua
@@ -39,6 +39,16 @@ local function MakeAdminPredicate(panel, section, pageDef)
 	end
 end
 
+local function MakeOwnerPredicate(panel, section, pageDef)
+	if type(pageDef.isOwner) ~= "function" then
+		return nil
+	end
+
+	return function()
+		return pageDef.isOwner(MakeCtx(panel, section))
+	end
+end
+
 -- Build a settings page from definition and populate with controls
 -- @param panel Frame The panel frame to build into
 -- @param pageDef table Page definition with sections and items
@@ -64,6 +74,7 @@ function R:Build(panel, pageDef)
 		})
 		sec.__sfPageBuilder = pb
 		sec.__sfAdminPredicate = MakeAdminPredicate(panel, sec, pageDef)
+		sec.__sfOwnerPredicate = MakeOwnerPredicate(panel, sec, pageDef)
 		sec.__sfFillHeight = secDef.fillHeight and true or false
 
 		local key = SectionKey(secDef)
@@ -99,7 +110,7 @@ function R:Build(panel, pageDef)
 				controls:AddTitleDivider(sec, item)
 
 			elseif t == "spacer" then
-				if item.visible ~= nil or item.adminOnly or item.enabled ~= nil then
+				if item.visible ~= nil or item.adminOnly or item.ownerOnly or item.enabled ~= nil then
 					controls:AddSpacerRow(sec, item)
 				else
 					sec:AddSpacer(item.height or 8)
@@ -169,6 +180,17 @@ function R:Build(panel, pageDef)
 					end
 				end
 				controls:AddEditBox(sec, opts)
+
+			elseif t == "moneyEdit" then
+				local opts = item
+				if type(opts.onCommit) == "function" then
+					local fn = opts.onCommit
+					opts = CopyTable(opts)
+					opts.onCommit = function(copper)
+						return fn(MakeCtx(panel, sec), copper)
+					end
+				end
+				controls:AddMoneyEdit(sec, opts)
 
 			elseif t == "dropdownIconButton" then
 				local opts = item

--- a/SpectrumFederation/modules/UI/Settings/Pages/LootHelper.lua
+++ b/SpectrumFederation/modules/UI/Settings/Pages/LootHelper.lua
@@ -144,6 +144,50 @@ local function IsAdmin()
 	return false
 end
 
+local function IsOwner()
+	local profile = GetActiveProfileObject(SF.SettingsStore)
+	if profile and profile.IsCurrentUserOwner then
+		local ok, res = pcall(profile.IsCurrentUserOwner, profile)
+		if ok then
+			return res and true or false
+		end
+	end
+	return false
+end
+
+local function IsRewardPotMode()
+	local profile = GetActiveProfileObject(SF.SettingsStore)
+	if profile and profile.IsRewardPotMode then
+		local ok, res = pcall(profile.IsRewardPotMode, profile)
+		if ok then
+			return res and true or false
+		end
+	end
+	return false
+end
+
+local function IsPointBasedMode()
+	local profile = GetActiveProfileObject(SF.SettingsStore)
+	if not profile then
+		return false
+	end
+	if profile.IsPointBasedMode then
+		local ok, res = pcall(profile.IsPointBasedMode, profile)
+		if ok then
+			return res and true or false
+		end
+	end
+	return not IsRewardPotMode()
+end
+
+local function GetRewardPotConfig()
+	local profile = GetActiveProfileObject(SF.SettingsStore)
+	if profile and profile.GetRewardPotConfig then
+		return profile:GetRewardPotConfig()
+	end
+	return nil
+end
+
 local function GetRaidCheckConfig()
 	local profile = GetActiveProfileObject(SF.SettingsStore)
 	if profile and profile.GetRaidCheckConfig then
@@ -1241,6 +1285,7 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 	local store = SF.SettingsStore
 
 	panel.__sfAddAdminSelectedId = panel.__sfAddAdminSelectedId or nil
+	panel.__sfRewardPotAdjustCopper = panel.__sfRewardPotAdjustCopper or 0
 
 	local function HasActiveProfile()
 		return GetActiveProfileObject(store) ~= nil or GetActiveProfileId(store) ~= nil
@@ -1497,10 +1542,45 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 					end,
 				},
 				{
+					type = "dropdown",
+					label = "Loot Mode",
+					ownerOnly = true,
+					tooltip = "Choose how this profile tracks raid participation. Point Based uses loot points. Reward Pot uses Attendance and a shared gold pot. Only the profile owner can change this. Switching modes hides the unused counter without wiping it.",
+					visible = function() return HasActiveProfile() end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						local profile = GetActiveProfileObject(store)
+						if profile and type(profile.GetLootMode) == "function" then
+							return profile:GetLootMode()
+						end
+						return (SF.LootModes and SF.LootModes.POINT_BASED) or "point_based"
+					end,
+					set = function(value)
+						local profile = GetActiveProfileObject(store)
+						if profile and type(profile.SetLootMode) == "function" then
+							profile:SetLootMode(value)
+						end
+					end,
+					options = function()
+						local pointBased = (SF.LootModes and SF.LootModes.POINT_BASED) or "point_based"
+						local rewardPot = (SF.LootModes and SF.LootModes.REWARD_POT) or "reward_pot"
+						return {
+							{ value = pointBased, label = "Point Based" },
+							{ value = rewardPot, label = "Reward Pot" },
+						}
+					end,
+					onValueChanged = function(ctx)
+						ctx.section:ClearMessage()
+						ctx.pageBuilder:Refresh()
+						ctx.pageBuilder:Reflow()
+					end,
+				},
+				{
 					type = "editbox",
 					label = "Point Name",
 					adminOnly = true,
 					tooltip = "Rename the point currency used by this profile. This changes labels like 'Points' in the Loot Helper window and related messages.",
+					visible = function() return HasActiveProfile() and IsPointBasedMode() end,
 					enabled = function() return ProfileActionsEnabled() end,
 					get = function()
 						local profile = GetActiveProfileObject(store)
@@ -1516,6 +1596,219 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 						end
 					end,
 					maxLetters = 24,
+				},
+				{ type = "titleDivider", text = "Reward Pot", visible = function() return HasActiveProfile() and IsRewardPotMode() end },
+				{
+					type = "display",
+					label = "Current Pot",
+					tooltip = "The current Reward Pot is the starting amount plus every logged add and subtract. It never goes below zero. Edit the pot in Settings; the raid window only displays it.",
+					visible = function() return HasActiveProfile() and IsRewardPotMode() end,
+					get = function()
+						local profile = GetActiveProfileObject(store)
+						local copper = 0
+						if profile and type(profile.GetCurrentRewardPotCopper) == "function" then
+							copper = profile:GetCurrentRewardPotCopper() or 0
+						end
+						if SF.FormatMoney then
+							return SF.FormatMoney(copper)
+						end
+						return tostring(copper)
+					end,
+				},
+				{
+					type = "moneyEdit",
+					label = "Starting Pot",
+					adminOnly = true,
+					tooltip = "Set the starting gold amount used when calculating the current Reward Pot. Changing this updates the current pot immediately.",
+					visible = function() return HasActiveProfile() and IsRewardPotMode() end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						local cfg = GetRewardPotConfig()
+						return cfg and cfg.startingPotCopper or 0
+					end,
+					set = function(value)
+						local profile = GetActiveProfileObject(store)
+						if profile and type(profile.SetRewardPotConfig) == "function" then
+							profile:SetRewardPotConfig({ startingPotCopper = value })
+						end
+					end,
+					onCommit = function(ctx)
+						if ctx and ctx.pageBuilder then
+							ctx.pageBuilder:Refresh()
+						end
+					end,
+				},
+				{
+					type = "dropdown",
+					label = "Raid Check Deduction",
+					adminOnly = true,
+					tooltip = "Choose how Raid Check reduces the Reward Pot when any evaluated profile member is unprepared. Flat subtracts a gold amount. Percent subtracts that percent of the current pot at click time, then stores the resulting gold amount.",
+					visible = function() return HasActiveProfile() and IsRewardPotMode() end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						local cfg = GetRewardPotConfig()
+						return (cfg and cfg.deductionType) or ((SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.FLAT) or "flat")
+					end,
+					set = function(value)
+						local profile = GetActiveProfileObject(store)
+						if not (profile and type(profile.SetRewardPotConfig) == "function") then
+							return
+						end
+						local cfg = GetRewardPotConfig() or {}
+						if cfg.deductionType == value then
+							return
+						end
+						profile:SetRewardPotConfig({
+							deductionType = value,
+							deductionValue = 0,
+						})
+					end,
+					options = function()
+						local flat = (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.FLAT) or "flat"
+						local percent = (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.PERCENT) or "percent"
+						return {
+							{ value = flat, label = "Flat Amount" },
+							{ value = percent, label = "Percent of Current Pot" },
+						}
+					end,
+					onValueChanged = function(ctx)
+						ctx.pageBuilder:Refresh()
+						ctx.pageBuilder:Reflow()
+					end,
+				},
+				{
+					type = "moneyEdit",
+					label = "Deduction Amount",
+					adminOnly = true,
+					tooltip = "Gold amount subtracted from the Reward Pot when a Raid Check finds any unprepared profile member. The amount is clamped so the pot never goes below zero.",
+					visible = function()
+						if not (HasActiveProfile() and IsRewardPotMode()) then
+							return false
+						end
+						local cfg = GetRewardPotConfig()
+						local percent = (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.PERCENT) or "percent"
+						return not (cfg and cfg.deductionType == percent)
+					end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						local cfg = GetRewardPotConfig()
+						return cfg and cfg.deductionValue or 0
+					end,
+					set = function(value)
+						local profile = GetActiveProfileObject(store)
+						if profile and type(profile.SetRewardPotConfig) == "function" then
+							profile:SetRewardPotConfig({ deductionValue = value })
+						end
+					end,
+				},
+				{
+					type = "editbox",
+					label = "Deduction Percent",
+					adminOnly = true,
+					tooltip = "Percent of the current Reward Pot subtracted when a Raid Check finds any unprepared profile member. Partial copper is rounded down. The log stores the gold amount calculated at click time, not a live percent.",
+					visible = function()
+						if not (HasActiveProfile() and IsRewardPotMode()) then
+							return false
+						end
+						local cfg = GetRewardPotConfig()
+						local percent = (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.PERCENT) or "percent"
+						return cfg and cfg.deductionType == percent or false
+					end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						local cfg = GetRewardPotConfig()
+						if not cfg then
+							return "0"
+						end
+						return tostring(cfg.deductionValue or 0)
+					end,
+					set = function(value)
+						local profile = GetActiveProfileObject(store)
+						if not (profile and type(profile.SetRewardPotConfig) == "function") then
+							return
+						end
+						local amount = tonumber(value)
+						if amount == nil or amount < 0 then
+							return
+						end
+						profile:SetRewardPotConfig({ deductionValue = amount })
+					end,
+					maxLetters = 8,
+				},
+				{
+					type = "moneyEdit",
+					label = "Add or Subtract",
+					adminOnly = true,
+					tooltip = "Enter an amount, then use Add or Subtract. Subtracting more than the current pot removes only what remains. These adjustments are logged.",
+					visible = function() return HasActiveProfile() and IsRewardPotMode() end,
+					enabled = function() return ProfileActionsEnabled() end,
+					get = function()
+						return panel.__sfRewardPotAdjustCopper or 0
+					end,
+					set = function(value)
+						panel.__sfRewardPotAdjustCopper = math.floor(tonumber(value) or 0)
+						if panel.__sfRewardPotAdjustCopper < 0 then
+							panel.__sfRewardPotAdjustCopper = 0
+						end
+					end,
+				},
+				{
+					type = "buttonRow",
+					adminOnly = true,
+					visible = function() return HasActiveProfile() and IsRewardPotMode() end,
+					enabled = function() return ProfileActionsEnabled() end,
+					{
+						text = "Add to Pot",
+						width = 140,
+						onClick = function(ctx)
+							ctx.section:ClearMessage()
+							local profile = GetActiveProfileObject(ctx.store)
+							if not (profile and type(profile.AdjustRewardPot) == "function") then
+								ctx.section:SetMessage("Reward Pot adjustments are unavailable.", "error")
+								return
+							end
+							local amount = math.floor(tonumber(panel.__sfRewardPotAdjustCopper) or 0)
+							local ok, err = profile:AdjustRewardPot(
+								(SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT) or "INCREMENT",
+								amount,
+								"MANUAL"
+							)
+							if not ok then
+								ctx.section:SetMessage(err or "Failed to add to the Reward Pot.", "error")
+								return
+							end
+							panel.__sfRewardPotAdjustCopper = 0
+							ctx.section:SetMessage("Added to the Reward Pot.", "success")
+							ctx.pageBuilder:Refresh()
+							ctx.pageBuilder:Reflow()
+						end,
+					},
+					{
+						text = "Subtract from Pot",
+						width = 180,
+						onClick = function(ctx)
+							ctx.section:ClearMessage()
+							local profile = GetActiveProfileObject(ctx.store)
+							if not (profile and type(profile.AdjustRewardPot) == "function") then
+								ctx.section:SetMessage("Reward Pot adjustments are unavailable.", "error")
+								return
+							end
+							local amount = math.floor(tonumber(panel.__sfRewardPotAdjustCopper) or 0)
+							local ok, err = profile:AdjustRewardPot(
+								(SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.DECREMENT) or "DECREMENT",
+								amount,
+								"MANUAL"
+							)
+							if not ok then
+								ctx.section:SetMessage(err or "Failed to subtract from the Reward Pot.", "error")
+								return
+							end
+							panel.__sfRewardPotAdjustCopper = 0
+							ctx.section:SetMessage("Subtracted from the Reward Pot.", "success")
+							ctx.pageBuilder:Refresh()
+							ctx.pageBuilder:Reflow()
+						end,
+					},
 				},
 				{
 					type = "button",
@@ -1549,7 +1842,7 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 				},
 				{ type = "spacer", height = 12 },
 				{ type = "heading", text = "Raid Check Profile Settings" },
-				{ type = "slider", label = "Points Per Raid Check", adminOnly = true, min = 0, max = 1, step = 0.5, tooltip = "Set how many points each prepared player earns when running a Raid Check.", enabled = function() return ProfileActionsEnabled() end, get = function() return GetRaidCheckPointsAwardPerCheck() end, set = function(v) SetRaidCheckPointsAwardPerCheck(v) end },
+				{ type = "slider", label = "Points Per Raid Check", adminOnly = true, min = 0, max = 1, step = 0.5, tooltip = "Set how many points each prepared player earns when running a Raid Check.", visible = function() return HasActiveProfile() and IsPointBasedMode() end, enabled = function() return ProfileActionsEnabled() end, get = function() return GetRaidCheckPointsAwardPerCheck() end, set = function(v) SetRaidCheckPointsAwardPerCheck(v) end },
 				{ type = "text", text = "Requirements to look for" },
 				{ type = "checkboxGrid", adminOnly = true, enabled = function() return ProfileActionsEnabled() end, items = { { label = "Gem in Sockets", tooltip = "Require every socket on equipped gear to contain a gem during raid checks.", get = function() return IsRaidCheckGemSocketsEnabled() end, set = function(v) SetRaidCheckGemSockets(v) end }, { label = "At Least One Meta Gem", tooltip = "Require at least one meta gem to be equipped in a valid socket during raid checks.", get = function() return IsRaidCheckMetaGemRequired() end, set = function(v) SetRaidCheckMetaGemRequired(v) end } } },
 				{ type = "text", text = "Enchants to look for" },
@@ -1578,7 +1871,7 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 					{ type = "buttonRow", adminOnly = true, enabled = function() return ProfileActionsEnabled() end, { text = "Pre-Raid Check", width = 180, onClick = function(ctx) if SF.RaidCheck and SF.RaidCheck.RunPreRaidCheck then SF.RaidCheck:RunPreRaidCheck() ctx.section:SetMessage("Pre-Raid Check started.", "info") else ctx.section:SetMessage("Raid Check is not available.", "error") end end }, { text = "Raid Check", width = 180, onClick = function(ctx) if SF.RaidCheck and SF.RaidCheck.RunRaidCheck then SF.RaidCheck:RunRaidCheck() ctx.section:SetMessage("Raid Check started.", "info") else ctx.section:SetMessage("Raid Check is not available.", "error") end end } },
 					{ type = "text", text = "Enable Whispers During..." },
 					{ type = "checkboxGrid", adminOnly = true, enabled = function() return ProfileActionsEnabled() end, items = { { label = "Pre-Raid Check", tooltip = "Whisper players after a Pre-Raid Check if they are missing required enchants or gems.", get = function() local cfg = GetRaidCheckConfig() return cfg and cfg.enableWhispersPreRaid or false end, set = function(value) SetRaidCheckWhispers("pre", value) if panel and panel.__sfPageBuilder then panel.__sfPageBuilder:Refresh() panel.__sfPageBuilder:Reflow() end end }, { label = "Raid Check", tooltip = "Whisper each player their Raid Check result. Players who are missing requirements are told what to fix; fully prepared players are told they earned a point.", get = function() local cfg = GetRaidCheckConfig() return cfg and cfg.enableWhispersRaid or false end, set = function(value) SetRaidCheckWhispers("raid", value) if panel and panel.__sfPageBuilder then panel.__sfPageBuilder:Refresh() panel.__sfPageBuilder:Reflow() end end } } },
-					{ type = "checkbox", label = "Whisper when a point is earned", adminOnly = true, tooltip = "Only applies when Raid Check whispers are enabled. When checked, prepared players are whispered that they earned a point.", visible = function() local cfg = GetRaidCheckConfig() return cfg and cfg.enableWhispersRaid or false end, enabled = function() return ProfileActionsEnabled() end, get = function() local cfg = GetRaidCheckConfig() if cfg == nil then return true end return cfg.enableWhispersRaidPrepared ~= false end, set = function(value) SetRaidCheckPreparedWhispers(value) if panel and panel.__sfPageBuilder then panel.__sfPageBuilder:Refresh() panel.__sfPageBuilder:Reflow() end end },
+					{ type = "checkbox", label = "Whisper when a point is earned", adminOnly = true, tooltip = "Only applies when Raid Check whispers are enabled. When checked, prepared players are whispered that they earned a point in Point Based mode, or an Attendance point in Reward Pot mode.", visible = function() local cfg = GetRaidCheckConfig() return cfg and cfg.enableWhispersRaid or false end, enabled = function() return ProfileActionsEnabled() end, get = function() local cfg = GetRaidCheckConfig() if cfg == nil then return true end return cfg.enableWhispersRaidPrepared ~= false end, set = function(value) SetRaidCheckPreparedWhispers(value) if panel and panel.__sfPageBuilder then panel.__sfPageBuilder:Refresh() panel.__sfPageBuilder:Reflow() end end },
 					{
 						type = "spacer",
 						adminOnly = true,
@@ -1619,7 +1912,7 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 			items = {
 				{ type = "scrollList", label = "Admins", adminOnly = true, height = 160, rowHeight = 20, removeAtlas = "common-icon-redx", compactColumns = true, removeColumnGap = 6, enabled = function() return ProfileActionsEnabled() end, getItems = function() return BuildAdminItems() end, onRemove = function(ctx, item) if type(ctx.store.RemoveAdminFromActiveProfile) ~= "function" then ctx.section:SetMessage("RemoveAdminFromActiveProfile() not implemented", "error") return end local ok, err = ctx.store:RemoveAdminFromActiveProfile(item.id) if not ok then ctx.section:SetMessage(err or "Failed to remove admin", "error") return end ctx.section:SetMessage("Admin removed.", "success") ctx.pageBuilder:Refresh() end },
 				{ type = "dropdownIconButton", label = "Add Admin", adminOnly = true, defaultText = "Select member", options = function() return BuildMemberOptions() end, get = function() return panel.__sfAddAdminSelectedId end, set = function(value) panel.__sfAddAdminSelectedId = value end, enabled = function() return ProfileActionsEnabled() end, iconAtlas = "common-icon-plus", iconToolTip = "Add the selected member as an admin for the active profile", iconEnabled = function() return ProfileActionsEnabled() and panel.__sfAddAdminSelectedId ~= nil end, onIconClick = function(ctx) if SF.Debug then SF.Debug:Info("UI", "Add Admin button clicked") end ctx.section:ClearMessage() local memberId = panel.__sfAddAdminSelectedId if SF.Debug then SF.Debug:Info("UI", "Selected memberId: %s", tostring(memberId)) end if not memberId then ctx.section:SetMessage("Select a member first.", "error") return end if type(ctx.store.AddAdminToActiveProfile) ~= "function" then ctx.section:SetMessage("AddAdminToActiveProfile() not implemented", "error") return end if SF.Debug then SF.Debug:Info("UI", "Calling AddAdminToActiveProfile with memberId: %s", tostring(memberId)) end local ok, err = ctx.store:AddAdminToActiveProfile(memberId) if SF.Debug then SF.Debug:Info("UI", "AddAdminToActiveProfile returned: ok=%s, err=%s", tostring(ok), tostring(err)) end if not ok then ctx.section:SetMessage(err or "Failed to add admin", "error") return end ctx.section:SetMessage("Admin added.", "success") ctx.pageBuilder:Refresh() end },
-				{ type = "button", label = "Transfer Points / Main Swap", adminOnly = true, buttonText = "Main Swap", width = 140, tooltip = "Transfer all point and member-history references from one existing profile member to another existing profile member, then remove the old character from the profile.", enabled = function() return ProfileActionsEnabled() end, onClick = function(ctx) ctx.section:ClearMessage() if type(ctx.store.TransferMemberHistoryInActiveProfile) ~= "function" then ctx.section:SetMessage("TransferMemberHistoryInActiveProfile() not implemented", "error") return end local memberOptions = BuildAllMemberOptions() if #memberOptions < 2 then ctx.section:SetMessage("Add at least two profile members before using Main Swap.", "error") return end dialogs:TransferMemberHistory("Transfer all point history from one profile member to another, then remove the old character from this profile?", "Transfer", memberOptions, memberOptions, function(sourceMemberId, targetMemberId) local ok, err = ctx.store:TransferMemberHistoryInActiveProfile(sourceMemberId, targetMemberId) if not ok then ctx.section:SetMessage(err or "Main Swap failed", "error") return end ctx.section:SetMessage("Main Swap completed.", "success") ctx.pageBuilder:Refresh() end) end },
+				{ type = "button", label = "Transfer Points / Main Swap", adminOnly = true, buttonText = "Main Swap", width = 140, tooltip = "Transfer loot points, Attendance, and member-history references from one existing profile member to another existing profile member, then remove the old character from the profile.", enabled = function() return ProfileActionsEnabled() end, onClick = function(ctx) ctx.section:ClearMessage() if type(ctx.store.TransferMemberHistoryInActiveProfile) ~= "function" then ctx.section:SetMessage("TransferMemberHistoryInActiveProfile() not implemented", "error") return end local memberOptions = BuildAllMemberOptions() if #memberOptions < 2 then ctx.section:SetMessage("Add at least two profile members before using Main Swap.", "error") return end dialogs:TransferMemberHistory("Transfer all point and Attendance history from one profile member to another, then remove the old character from this profile?", "Transfer", memberOptions, memberOptions, function(sourceMemberId, targetMemberId) local ok, err = ctx.store:TransferMemberHistoryInActiveProfile(sourceMemberId, targetMemberId) if not ok then ctx.section:SetMessage(err or "Main Swap failed", "error") return end ctx.section:SetMessage("Main Swap completed.", "success") ctx.pageBuilder:Refresh() end) end },
 			},
 		},
 	}
@@ -1635,6 +1928,9 @@ local function BuildLootHelperDefinition(panel, sectionIds)
 	return {
 		isAdmin = function()
 			return IsAdmin()
+		end,
+		isOwner = function()
+			return IsOwner()
 		end,
 		sections = sections,
 	}

--- a/SpectrumFederation/modules/UI/Settings/Pages/LootLogs.lua
+++ b/SpectrumFederation/modules/UI/Settings/Pages/LootLogs.lua
@@ -135,6 +135,10 @@ local EVENT_TYPE_COLORS = {
 	ADMIN_ADDED = "|cff66ff66",
 	ADMIN_REMOVED = "|cffff6666",
 	MAIN_SWAP = "|cff9966ff",
+	LOOT_MODE_CHANGE = "|cffcc99ff",
+	REWARD_POT_CONFIG_CHANGE = "|cffffcc66",
+	REWARD_POT_CHANGE = "|cffffd700",
+	ATTENDANCE_CHANGE = "|cff66ccff",
 }
 
 local EVENT_TYPE_LABELS = {
@@ -149,6 +153,10 @@ local EVENT_TYPE_LABELS = {
 	ADMIN_ADDED = "Admin Added",
 	ADMIN_REMOVED = "Admin Removed",
 	MAIN_SWAP = "Main Swap",
+	LOOT_MODE_CHANGE = "Loot Mode Change",
+	REWARD_POT_CONFIG_CHANGE = "Reward Pot Config",
+	REWARD_POT_CHANGE = "Reward Pot Change",
+	ATTENDANCE_CHANGE = "Attendance Change",
 }
 
 function GetEventTypeLabel(eventType)
@@ -185,6 +193,24 @@ local function FormatPointAmount(amount)
 	local text = string.format("%.2f", amount)
 	text = text:gsub("0+$", ""):gsub("%.$", "")
 	return text
+end
+
+local function FormatCopperAmount(amount)
+	amount = math.floor(tonumber(amount) or 0)
+	if SF.FormatMoney then
+		return SF.FormatMoney(amount)
+	end
+	return tostring(amount)
+end
+
+local function FormatLootMode(mode)
+	if mode == (SF.LootModes and SF.LootModes.REWARD_POT) or mode == "reward_pot" then
+		return "Reward Pot"
+	end
+	if mode == (SF.LootModes and SF.LootModes.POINT_BASED) or mode == "point_based" then
+		return "Point Based"
+	end
+	return FormatLabel(mode)
 end
 
 local function GetArmorSlotLabel(slot)
@@ -242,6 +268,46 @@ local function BuildActionText(eventType, data, author)
 		-- Strip realm for cleaner display if present
 		local shortName = sourceName:match("^([^%-]+)") or sourceName
 		return string.format("Consolidated from %s", shortName)
+	elseif eventType == "LOOT_MODE_CHANGE" then
+		return string.format("%s -> %s", FormatLootMode(data.oldMode), FormatLootMode(data.newMode))
+	elseif eventType == "REWARD_POT_CONFIG_CHANGE" then
+		local starting = FormatCopperAmount(data.startingPotCopper)
+		local deductionType = data.deductionType
+		if deductionType == (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.PERCENT) or deductionType == "percent" then
+			return string.format("Starting %s; deduct %s%%", starting, FormatPointAmount(data.deductionValue or 0))
+		end
+		return string.format("Starting %s; deduct %s", starting, FormatCopperAmount(data.deductionValue))
+	elseif eventType == "REWARD_POT_CHANGE" then
+		local amount = (SF.LootLog and SF.LootLog.GetRewardPotChangeAmount and SF.LootLog.GetRewardPotChangeAmount(data)) or 0
+		local money = FormatCopperAmount(amount)
+		if data.reason == "RAID_DEDUCTION" or author == "Raid Check" then
+			if data.deductionType == (SF.RewardPotDeductionTypes and SF.RewardPotDeductionTypes.PERCENT) or data.deductionType == "percent" then
+				return string.format("Raid Check deducted %s (%s%%)", money, FormatPointAmount(data.percent or 0))
+			end
+			return string.format("Raid Check deducted %s", money)
+		end
+		if data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT) then
+			return string.format("Pot Increased (+%s)", money)
+		elseif data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.DECREMENT) then
+			return string.format("Pot Decreased (-%s)", money)
+		end
+		return FormatLabel(data.change or "?")
+	elseif eventType == "ATTENDANCE_CHANGE" then
+		local isRaidCheck = (data.reason == "RAID_CHECK") or (author == "Raid Check")
+		local amount = (SF.LootLog and SF.LootLog.GetAttendanceChangeAmount and SF.LootLog.GetAttendanceChangeAmount(data)) or 1
+		if isRaidCheck and data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT) then
+			return string.format("Raid Check prepared (+%s)", FormatPointAmount(amount))
+		elseif isRaidCheck then
+			return string.format("Raid Check change (%s)", FormatLabel(data.change or "?"))
+		end
+
+		if data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.INCREMENT) then
+			return string.format("Attendance Increased (+%s)", FormatPointAmount(amount))
+		elseif data.change == (SF.LootLogPointChangeTypes and SF.LootLogPointChangeTypes.DECREMENT) then
+			return string.format("Attendance Decreased (-%s)", FormatPointAmount(amount))
+		end
+
+		return FormatLabel(data.change or "?")
 	end
 
 	return ""

--- a/SpectrumFederation/modules/core.lua
+++ b/SpectrumFederation/modules/core.lua
@@ -148,6 +148,64 @@ function SF:Now()
     return (GetServerTime and GetServerTime()) or time()
 end
 
+-- ============================================================================
+-- Money helpers (WoW copper)
+-- ============================================================================
+
+SF.COPPER_PER_SILVER = 100
+SF.COPPER_PER_GOLD = 10000
+
+-- Convert gold/silver/copper components into a non-negative copper integer.
+-- @param gold number|nil
+-- @param silver number|nil
+-- @param copper number|nil
+-- @return number copper
+function SF.MoneyFromCoins(gold, silver, copper)
+	local g = math.floor(tonumber(gold) or 0)
+	local s = math.floor(tonumber(silver) or 0)
+	local c = math.floor(tonumber(copper) or 0)
+	if g < 0 then g = 0 end
+	if s < 0 then s = 0 end
+	if c < 0 then c = 0 end
+	local total = (g * SF.COPPER_PER_GOLD) + (s * SF.COPPER_PER_SILVER) + c
+	if total < 0 then
+		return 0
+	end
+	return total
+end
+
+-- Split a copper amount into gold, silver, and copper components.
+-- @param copper number|nil
+-- @return number gold
+-- @return number silver
+-- @return number copper
+function SF.MoneyToCoins(copper)
+	copper = math.floor(tonumber(copper) or 0)
+	if copper < 0 then
+		copper = 0
+	end
+	local gold = math.floor(copper / SF.COPPER_PER_GOLD)
+	local remain = copper - (gold * SF.COPPER_PER_GOLD)
+	local silver = math.floor(remain / SF.COPPER_PER_SILVER)
+	remain = remain - (silver * SF.COPPER_PER_SILVER)
+	return gold, silver, remain
+end
+
+-- Format a copper amount using WoW coin icons when available.
+-- @param copper number|nil
+-- @return string
+function SF.FormatMoney(copper)
+	copper = math.floor(tonumber(copper) or 0)
+	if copper < 0 then
+		copper = 0
+	end
+	if GetCoinTextureString then
+		return GetCoinTextureString(copper)
+	end
+	local gold, silver, remain = SF.MoneyToCoins(copper)
+	return string.format("%dg %ds %dc", gold, silver, remain)
+end
+
 -- Get the addon's current version from metadata
 -- @return string Addon version or "Unknown" if not found
 function SF:GetAddonVersion()

--- a/docs/features/loot-helper.md
+++ b/docs/features/loot-helper.md
@@ -1,6 +1,8 @@
 # Loot Helper
 
-Loot Helper is the addon's main raid roster and point-management window. It combines the active profile's members with the current raid roster so admins can make routine loot decisions without editing profile data by hand.
+Loot Helper is the addon's main raid roster window. It combines the active profile's members with the current raid roster so admins can make routine loot decisions without editing profile data by hand.
+
+Each profile uses one loot mode: [Point Based](point-based.md) or [Reward Pot](reward-pot.md). Point Based is the default. The owner of the profile chooses the mode.
 
 ## When the window appears
 
@@ -17,7 +19,10 @@ The window's position, size, and minimized state are saved locally.
 
 ## Understanding the roster
 
-Profile members show their class or specialization icon, class-colored name, current point balance, and equipment-history button.
+Profile members show their class or specialization icon, class-colored name, a mode-specific total, and an equipment-history button.
+
+- In **Point Based**, the title uses the profile's point name and each row shows loot points.
+- In **Reward Pot**, the title shows Attendance, each row shows Attendance, and the current Reward Pot appears above the list.
 
 When you are in a raid, the window also identifies raid members who are not in the active profile. An admin can add them with the plus button. The **Show Members not in raid** setting controls whether absent profile members remain visible.
 
@@ -25,17 +30,20 @@ When you are in a raid, the window also identifies raid members who are not in t
 
 Profile admins can:
 
-- increase or decrease points in half-point steps;
+- increase or decrease loot points in half-point steps in Point Based, or Attendance by one in Reward Pot;
 - add current raid members to the profile;
 - mark equipment categories used or available;
 - create, select, rename, and delete profiles;
-- change the profile's point name;
+- change the profile's point name in Point Based;
+- add or subtract Reward Pot gold and configure the pot in Reward Pot;
 - add or remove admins;
-- transfer one character's point and equipment history to another with **Main Swap**;
+- transfer one character's history to another with **Main Swap**;
 - configure and run Raid Checks;
 - start sync sessions and, when acting as coordinator, end them.
 
-Non-admins can view the roster, points, equipment history, logs, and synchronized profile data. Shared-data controls such as point/equipment changes, profile settings, Raid Check, sessions, and admin management are hidden or disabled in the UI.
+Only the profile owner can change loot mode.
+
+Non-admins can view the roster, totals, the Reward Pot amount, equipment history, logs, and synchronized profile data. Shared-data controls such as point, Attendance, pot, and equipment changes, profile settings, Raid Check, sessions, and admin management are hidden or disabled in the UI.
 
 Creating, selecting, and deleting a local profile copy are available without profile-admin status. Those local actions are distinct from authorization to write shared profile history during synchronization.
 
@@ -47,7 +55,7 @@ Select the equipment button on a member row to open the equipment window. It tra
 - weapon and off-hand;
 - two ring uses and two trinket uses.
 
-This is profile history, not a live inspection of equipped items. Admins toggle a category when the member uses or regains that loot opportunity. Toggling creates an equipment-history log entry but does not change the member's point balance; use the separate point controls when an award should also spend or return points.
+This is profile history, not a live inspection of equipped items. Admins toggle a category when the member uses or regains that loot opportunity. Toggling creates an equipment-history log entry and does not change loot points or Attendance.
 
 The separate [Raid Check](raid-check.md) equipment page inspects current gear for enchants and gems.
 
@@ -59,7 +67,8 @@ A profile includes:
 
 - a stable ID and editable display name;
 - an owner, admins, and members;
-- a customizable point name and point balances;
+- a loot mode, customizable point name, loot-point balances, and Attendance balances;
+- Reward Pot starting amount and deduction settings;
 - equipment-category state;
 - Raid Check requirements and saved equipment snapshots;
 - raid-wide safe-mode preferences;
@@ -71,12 +80,14 @@ The current **Reset Current Profile** action is a placeholder and does not reset
 
 ## Main Swap
 
-**Transfer Points / Main Swap** consolidates an old profile character into another existing profile member. It rewrites relevant point and equipment history to the target, removes the source member, and records the operation in Loot Logs.
+**Transfer Points / Main Swap** consolidates an old profile character into another existing profile member. It rewrites relevant point, Attendance, and equipment history to the target, removes the source member, and records the operation in Loot Logs.
 
 Both source and target must already be profile members. Review the selected names carefully; this is an admin-only data migration, not a temporary display preference.
 
 ## Related pages
 
+- [Point Based](point-based.md)
+- [Reward Pot](reward-pot.md)
 - [Raid Check](raid-check.md)
 - [Sync Sessions](sync-sessions.md)
 - [Loot Logs](loot-logs.md)

--- a/docs/features/loot-logs.md
+++ b/docs/features/loot-logs.md
@@ -1,6 +1,6 @@
 # Loot Logs
 
-Loot Logs are the audit history for the active loot profile. They are also the source used to rebuild member point balances and equipment-category state and to synchronize changes between clients.
+Loot Logs are the audit history for the active loot profile. They are also the source used to rebuild member loot-point and Attendance balances, equipment-category state, Reward Pot totals, and to synchronize changes between clients.
 
 Open **Loot Logs** in the Spectrum Federation settings window.
 
@@ -9,7 +9,11 @@ Open **Loot Logs** in the Spectrum Federation settings window.
 The log includes:
 
 - profile creation and renames;
-- point increases and decreases, including Raid Check awards;
+- loot-point increases and decreases, including Raid Check awards;
+- Attendance increases and decreases, including Raid Check awards;
+- loot-mode changes;
+- Reward Pot starting amount and deduction settings;
+- Reward Pot gold added, subtracted, or deducted by Raid Check;
 - equipment categories marked used or available;
 - member role changes;
 - point-name changes;
@@ -18,6 +22,8 @@ The log includes:
 - Main Swap consolidations.
 
 Each row shows the date, change type, affected member when applicable, a readable action, and the author.
+
+Reward Pot amounts appear as gold, silver, and copper. A percent Raid Check deduction is stored as the gold amount calculated when the check ran.
 
 ## Filter the history
 
@@ -33,7 +39,7 @@ Filters apply together. Select **Clear** to return to the complete history. The 
 
 Corrections create new entries instead of modifying old ones. This preserves the audit trail and lets clients identify and request missing ranges reliably.
 
-Member point and equipment state is derived by replaying the relevant entries. Profile synchronization deduplicates entries by their stable author-and-counter ID.
+Member loot-point, Attendance, equipment, loot-mode, and Reward Pot state is derived by replaying the relevant entries. Profile synchronization deduplicates entries by their stable author-and-counter ID.
 
 ## Debug logs are different
 

--- a/docs/features/point-based.md
+++ b/docs/features/point-based.md
@@ -1,0 +1,30 @@
+# Point Based
+
+Point Based is the default loot mode. Profile members earn a loot-point balance that the Loot Helper roster displays and that Raid Check can increase when a player is prepared.
+
+Existing profiles start in Point Based. Switching to [Reward Pot](reward-pot.md) hides loot points without deleting them; switching back restores the same balances.
+
+## What you see
+
+The Loot Helper window title uses the profile's point name. Each profile member shows their current loot-point balance. Profile admins can raise or lower that balance in half-point steps.
+
+Attendance is not shown in this mode. If the profile later uses Reward Pot, Attendance already earned there remains stored until you switch back.
+
+## Raid Check
+
+**Pre-Raid Check** reports missing requirements. It does not change loot points.
+
+**Raid Check** inspects only profile members who are currently in the raid. Prepared members receive the profile's **Points Per Raid Check** award (`0`, `0.5`, or `1`). A member with no usable inspect data counts as unprepared and does not receive points.
+
+Configure the award and gear requirements under **Loot Helper → Profile**. Only profile admins can change those settings or run a check.
+
+## Equipment history
+
+The gear button still records whether a loot category has been used. In Point Based, that history is separate from the up and down point controls.
+
+## Related pages
+
+- [Reward Pot](reward-pot.md)
+- [Loot Helper](loot-helper.md)
+- [Raid Check](raid-check.md)
+- [Loot Logs](loot-logs.md)

--- a/docs/features/raid-check.md
+++ b/docs/features/raid-check.md
@@ -76,7 +76,7 @@ Templates support:
 - `{point_name}`
 - `{points_awarded}`
 
-For missing requirements, the addon records when each profile member was whispered and suppresses repeated whispers of the same check type on the same calendar day. Prepared-player whispers are controlled separately and are sent only after a successful Raid Check award. In Reward Pot mode, that prepared whisper uses Attendance rather than the profile's loot-point name.
+For missing requirements, the addon records when each profile member was whispered and suppresses repeated whispers of the same check type on the same calendar day. Prepared-player whispers are controlled separately and are sent only after a successful Raid Check award. In Reward Pot mode, `{point_name}` in both missing and prepared whispers uses Attendance rather than the profile's loot-point name.
 
 ## What gets recorded
 

--- a/docs/features/raid-check.md
+++ b/docs/features/raid-check.md
@@ -1,6 +1,6 @@
 # Raid Check
 
-Raid Check inspects group members' current equipment against requirements stored in the active loot profile. It can report missing gear, enchants, and gems, optionally whisper results, and award points to prepared profile members.
+Raid Check inspects group members' current equipment against requirements stored in the active loot profile. It can report missing gear, enchants, and gems, optionally whisper results, and award loot points or Attendance to prepared profile members.
 
 Only an admin of the active profile can run or configure a check.
 
@@ -10,37 +10,47 @@ Open **Loot Helper → Profile → Raid Check Profile Settings**.
 
 For each profile, admins can choose:
 
-- the point award per successful Raid Check: `0`, `0.5`, or `1`;
+- in [Point Based](point-based.md) mode, the loot-point award per successful Raid Check: `0`, `0.5`, or `1`;
 - whether every socket on socketed equipment must contain a gem;
 - whether at least one meta gem is required;
 - which equipment categories require enchant checks.
 
-All enchant categories and socketed-gem checks are enabled for a new profile. The meta-gem requirement is disabled, and the default point award is `0.5`.
+All enchant categories and socketed-gem checks are enabled for a new profile. The meta-gem requirement is disabled, and the default Point Based award is `0.5`.
+
+In [Reward Pot](reward-pot.md) mode, **Points Per Raid Check** is hidden. Prepared members receive `1` Attendance instead, and the pot uses the profile's Raid Check deduction settings.
+
+## Who is evaluated
+
+**Pre-Raid Check** and **Raid Check** both inspect profile members who are currently in the raid. Players who are in the raid but not in the profile are ignored. Players who are in the profile but not in the raid are ignored.
 
 ## Pre-Raid Check and Raid Check
 
-Both modes inspect every available party or raid unit.
-
 **Pre-Raid Check**
 
-- reports missing configured requirements to the admin who ran the check as system messages;
-- can whisper offenders who are missing requirements when that setting is enabled;
-- does not award points.
+- reports missing configured requirements and missing inspect data to the admin who ran the check as system messages;
+- can whisper players who are missing configured enchants or gems when that setting is enabled;
+- does not award loot points or Attendance;
+- does not change the Reward Pot.
 
 **Raid Check**
 
-- reports missing configured requirements to the admin who ran the check as system messages;
-- awards the configured amount to each prepared player who belongs to the active profile;
-- skips point awards for prepared players who are not profile members;
+- reports missing configured requirements and missing inspect data to the admin who ran the check as system messages;
+- in Point Based mode, awards the configured loot points to each prepared profile member in the raid;
+- in Reward Pot mode, awards `1` Attendance to each prepared profile member in the raid;
+- in Reward Pot mode, subtracts from the pot once if any evaluated member is unprepared;
 - can whisper missing and prepared results when those settings are enabled.
 
+A member with no usable inspect data is unprepared. That includes out of range, never inspected, and incomplete item data. Inspect gaps are listed in the admin summary and do not send a missing-gear whisper.
+
 Run checks from **Loot Helper → Session**, or use `/sf raidcheck pre` and `/sf raidcheck raid`.
+
+Running Raid Check more than once can award points or Attendance again and, in Reward Pot mode, deduct from the pot again.
 
 ## Inspect-data limitations
 
 WoW only exposes another player's equipment when that player can be inspected. Results may temporarily show **Loading**, **Out of range**, **Unavailable**, or a saved snapshot while fresh data is collected.
 
-Raid Check does not treat partial item data as a definite failure and does not award points until the inspection is usable. Inspect stubs can already show a base item level and empty sockets from the item tooltip before gems and enchants populate; bonus IDs and item context are the signals that the inspect has resolved. Move close to unresolved players and refresh the equipment snapshot before rerunning the check.
+Inspect stubs can already show a base item level and empty sockets from the item tooltip before gems and enchants populate. Move close to unresolved players and refresh the equipment snapshot before rerunning the check.
 
 ## Equipment audit page
 
@@ -57,7 +67,7 @@ Saved profile snapshots allow absent members or temporarily unavailable inspecti
 
 ## Whispers
 
-Whispers are disabled by default. Admins can enable them separately for Pre-Raid Check and Raid Check. Whisper settings do not control the admin-facing system-message summary; that summary always lists every player who is missing configured requirements.
+Whispers are disabled by default. Admins can enable them separately for Pre-Raid Check and Raid Check. Whisper settings do not control the admin-facing system-message summary; that summary always lists every evaluated player who is missing configured requirements or inspect data.
 
 Templates support:
 
@@ -66,8 +76,8 @@ Templates support:
 - `{point_name}`
 - `{points_awarded}`
 
-For missing requirements, the addon records when each profile member was whispered and suppresses repeated whispers of the same check type on the same calendar day. Prepared-player whispers are controlled separately and are sent only after a successful Raid Check point award.
+For missing requirements, the addon records when each profile member was whispered and suppresses repeated whispers of the same check type on the same calendar day. Prepared-player whispers are controlled separately and are sent only after a successful Raid Check award. In Reward Pot mode, that prepared whisper uses Attendance rather than the profile's loot-point name.
 
 ## What gets recorded
 
-Raid Check point awards are normal point-change log entries with **Raid Check** as the author and can be reviewed on the [Loot Logs](loot-logs.md) page.
+Point Based awards are loot-point log entries with **Raid Check** as the author. Reward Pot awards are Attendance log entries with the same author. A Reward Pot deduction is a Reward Pot change with **Raid Check** as the author. Review them on the [Loot Logs](loot-logs.md) page.

--- a/docs/features/reward-pot.md
+++ b/docs/features/reward-pot.md
@@ -1,0 +1,58 @@
+# Reward Pot
+
+Reward Pot is a second loot mode for a profile. Instead of showing loot points, the raid window shows **Attendance** for each profile member and the current gold in a shared Reward Pot.
+
+Only the profile owner can switch a profile between Point Based and Reward Pot. Switching modes hides the unused counter without wiping it. Loot points earned in Point Based remain stored while Reward Pot is active, and Attendance remains stored while Point Based is active.
+
+## Attendance
+
+The Loot Helper window title shows **Attendance**. Each profile member's row shows their Attendance total.
+
+Profile admins can raise or lower Attendance one point at a time. Decreasing Attendance at zero does nothing. Attendance never goes below zero.
+
+**Raid Check** awards `1` Attendance to each prepared profile member who is in the raid. **Pre-Raid Check** never changes Attendance.
+
+## The pot
+
+The current pot is the starting amount plus every logged add and subtract. It never goes below zero.
+
+The raid window displays the current pot above the roster. It does not include editors. Profile admins add or subtract gold, and set the starting amount, under **Loot Helper → Profile**.
+
+Gold amounts use WoW's gold, silver, and copper coins.
+
+## Raid Check deductions
+
+When **Raid Check** finds any evaluated profile member unprepared, it subtracts from the pot once for that click.
+
+The deduction can be:
+
+- a flat gold amount; or
+- a percent of the current pot at the moment you run the check.
+
+A percent that does not land on a whole copper amount is rounded down. The log stores the gold amount that was actually subtracted, not a live percent. Later pot changes do not rewrite that earlier deduction.
+
+Example: a 10% deduction from a 500,000 gold pot records a 50,000 gold subtraction. Adding 1,000 gold afterward leaves 451,000 gold, not 501,000 gold.
+
+If the configured amount is larger than the current pot, only the remaining gold is removed. A deduction of zero is skipped.
+
+Missing inspect data counts as unprepared. Out of range, never inspected, or incomplete item data all prevent Attendance awards and can trigger the one pot deduction.
+
+Running Raid Check more than once can award Attendance and deduct from the pot again. Use Loot Logs if you need to correct an extra run.
+
+## Settings
+
+Open **Loot Helper → Profile** while Reward Pot is active to:
+
+- see the current pot;
+- set the starting pot;
+- choose a flat or percent Raid Check deduction;
+- add or subtract gold.
+
+**Points Per Raid Check** is hidden in this mode because Raid Check awards Attendance instead.
+
+## Related pages
+
+- [Point Based](point-based.md)
+- [Loot Helper](loot-helper.md)
+- [Raid Check](raid-check.md)
+- [Loot Logs](loot-logs.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,7 +35,7 @@ You can also enter `/sf loot` to enable Loot Helper and ask it to show the windo
 
 The new profile becomes active immediately. Its creator is added as the owner, first member, and first admin.
 
-Profiles hold their own roster, point name, admin list, Raid Check configuration, safe-mode options, equipment snapshots, and change history. Switching profiles changes the data shown by Loot Helper and Loot Logs.
+Profiles hold their own roster, loot mode, point name, Attendance, Reward Pot, admin list, Raid Check configuration, safe-mode options, equipment snapshots, and change history. Switching profiles changes the data shown by Loot Helper and Loot Logs.
 
 ## Add and manage members
 
@@ -43,11 +43,14 @@ Join a raid with the people you want to add. In the Loot Helper roster, players 
 
 For profile members:
 
-- The up and down buttons adjust the member's point balance in half-point steps.
+- In Point Based mode, the up and down buttons adjust the member's loot-point balance in half-point steps.
+- In Reward Pot mode, those buttons adjust Attendance by one, and the current pot is shown above the list.
 - The equipment button opens that member's equipment-category history.
 - Admins can mark equipment categories used or available; all users can view them.
 
 Enable **Show Members not in raid** if you want the roster to include offline or absent profile members.
+
+The profile owner can switch loot mode under **Loot Helper → Profile**. See [Point Based](features/point-based.md) and [Reward Pot](features/reward-pot.md).
 
 ## Start a shared session
 
@@ -63,10 +66,10 @@ The coordinator compares profile history with other online admins, then announce
 
 Profile admins can configure requirements under **Loot Helper → Profile**, then run:
 
-- **Pre-Raid Check** to report preparation problems without awarding points.
-- **Raid Check** to report problems and award the configured points to prepared profile members.
+- **Pre-Raid Check** to report preparation problems without awarding points, Attendance, or pot changes.
+- **Raid Check** to report problems and award loot points in Point Based mode, or Attendance and a possible pot deduction in Reward Pot mode.
 
-See [Raid Check](features/raid-check.md) before enabling automatic whispers or point awards.
+See [Raid Check](features/raid-check.md) before enabling automatic whispers or awards.
 
 ## Useful commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # Spectrum Federation
 
-Spectrum Federation is a World of Warcraft Retail addon for coordinating guild raid loot. It keeps shared loot profiles, member point balances, equipment-slot history, raid-readiness checks, and profile changes in one place.
+Spectrum Federation is a World of Warcraft Retail addon for coordinating guild raid loot. It keeps shared loot profiles, member loot points and Attendance, a Reward Pot, equipment-slot history, raid-readiness checks, and profile changes in one place.
 
 ## What the addon provides
 
-- **Loot Helper** — a raid roster window where profile admins manage points, add raid members, and record which equipment categories a member has used.
-- **Loot profiles** — separate, named sets of members, admins, point rules, Raid Check options, and history.
+- **Loot Helper** — a raid roster window where profile admins manage loot points or Attendance, add raid members, and record which equipment categories a member has used.
+- **Loot profiles** — separate, named sets of members, admins, Point Based or Reward Pot rules, Raid Check options, and history.
 - **Sync sessions** — group-wide profile and log synchronization, with automatic catch-up for late joiners and clients that missed updates.
-- **Raid Check** — configurable enchant and gem checks, optional whispers, and point awards for prepared profile members.
-- **Loot Logs** — a filterable history of point, equipment, profile, safe-mode, admin, and main-swap changes.
+- **Raid Check** — configurable enchant and gem checks, optional whispers, and loot-point or Attendance awards for prepared profile members.
+- **Loot Logs** — a filterable history of point, Attendance, Reward Pot, equipment, profile, safe-mode, admin, and main-swap changes.
 - **Gameplay settings** — per-specialization control of WoW's Press and Hold Casting option.
 
 [Install and get started](getting-started.md){ .md-button .md-button--primary }
@@ -16,7 +16,7 @@ Spectrum Federation is a World of Warcraft Retail addon for coordinating guild r
 
 ## Who can change shared data?
 
-Everyone with the addon can view the active profile. Profile admins can change points and equipment history, manage profile settings and admins, run Raid Checks, and coordinate sync sessions. The profile creator is its initial owner and admin.
+Everyone with the addon can view the active profile. Profile admins can change loot points, Attendance, the Reward Pot, and equipment history, manage profile settings and admins, run Raid Checks, and coordinate sync sessions. Only the profile owner can change loot mode. The profile creator is its initial owner and admin.
 
 ## About Spectrum Federation
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -18,7 +18,7 @@ A current raid member who is not in the profile appears as an addable row only f
 
 ## I cannot change points, equipment, or profile settings
 
-These operations require admin status in the active profile. The profile owner is always an admin and cannot be removed through the settings page.
+These operations require admin status in the active profile. Changing loot mode requires the profile owner. The profile owner is always an admin and cannot be removed through the settings page.
 
 If a recently changed admin list differs between clients, synchronize the profile or restart the session after admins have converged.
 
@@ -49,19 +49,19 @@ WoW throttles inspection and requires other players to be nearby and inspectable
 - Wait for item links and inspection data to populate.
 - Rerun the check after pending statuses resolve.
 
-Raid Check intentionally avoids treating incomplete item data as a definite failure or awarding points from it.
+Raid Check treats incomplete item data as unprepared. Move closer, refresh the snapshot, then rerun the check.
 
-## A player did not receive a Raid Check point
+## A player did not receive a Raid Check point or Attendance
 
 Confirm that:
 
 - you ran **Raid Check**, not **Pre-Raid Check**;
 - the player passed every enabled requirement;
 - inspection was complete;
-- the player belongs to the active profile;
-- **Points Per Raid Check** is greater than zero.
+- the player belongs to the active profile and is in the raid;
+- in Point Based mode, **Points Per Raid Check** is greater than zero.
 
-The point change appears in Loot Logs with **Raid Check** as its author.
+The award appears in Loot Logs with **Raid Check** as its author. In Reward Pot mode, prepared players receive Attendance rather than loot points.
 
 ## A whisper was not sent
 

--- a/docs/settings-ui.md
+++ b/docs/settings-ui.md
@@ -51,9 +51,11 @@ This page selects and manages the active profile. It includes:
 
 - profile creation, selection, rename, reset, and deletion;
 - profile owner and point-name display;
+- owner-only loot mode: Point Based or Reward Pot;
+- Reward Pot starting amount, Raid Check deduction, and gold add/subtract controls when Reward Pot is active;
 - Raid Check point, gem, meta-gem, and enchant requirements.
 
-Rename and profile-specific configuration are admin-only. Creating a profile makes the creator its owner and first admin.
+Rename and profile-specific configuration are admin-only. Only the profile owner can change loot mode. Creating a profile makes the creator its owner and first admin.
 
 **Reset Current Profile** is currently a nonfunctional placeholder and reports that it is not implemented.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ nav:
   - Getting Started: getting-started.md
   - Features:
     - Loot Helper: features/loot-helper.md
+    - Point Based: features/point-based.md
+    - Reward Pot: features/reward-pot.md
     - Raid Check: features/raid-check.md
     - Sync Sessions: features/sync-sessions.md
     - Loot Logs: features/loot-logs.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a second Loot Helper profile mode, **Reward Pot**, while keeping existing **Point Based** behavior. Owners can switch modes without wiping loot points or Attendance. Reward Pot shows Attendance in the raid window, a shared gold pot, and uses Raid Check to award Attendance and optionally deduct from the pot.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without functional changes)
- [x] Documentation update
- [ ] Other (please describe):

## Changes Made

- Add loot mode, Attendance, and Reward Pot logs, with snapshot import that does not clobber omitted fields.
- Raid Check evaluates in-raid profile members; missing inspect data counts as unprepared. Reward Pot awards Attendance and applies one logged pot deduction when any evaluated member is unprepared.
- Owner-only loot mode control, admin pot editors in Profile settings, raid-window pot display, Attendance `+`/`-`, and Loot Logs rendering for the new event types.
- User-facing docs for Point Based and Reward Pot, plus updates to Loot Helper, Raid Check, Loot Logs, settings, and getting started.
- Addon version set to `1.1.0-beta.1`.

## Checklist

- [x] I have tested these changes in-game
- [x] My code follows the project's style guidelines
- [x] I have added/updated documentation as needed
- [x] I have added appropriate Debug Logging if necessary
- [x] I have added/updated localization strings in `locale/enUS.lua` if applicable
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published
- [x] I've linked this PR to any related issues in the [repo project](https://github.com/users/OsulivanAB/projects/1).

## Testing

### In-Game Testing Details

**WoW Client Type:**
- [x] Retail
- [ ] Classic
- [ ] PTR
- [ ] Beta

**Game Version:** <!-- e.g., 11.0.2 -->

**Additional Testing Info**

Automated validation passed:

- `python3 .github/scripts/lint_all.py`
- `python3 .github/scripts/validate_packaging.py`
- `python3 .github/scripts/validate_docs.py`

In-game verification is still needed for owner-only mode switching, pot add/subtract, Attendance `+/-`, and Raid Check awards/deductions.

## Screenshots/Videos

<!-- If applicable, add screenshots or video links to demonstrate the changes -->

## Additional Notes

Google Sheet sync is unchanged. Ready Check is not hooked. Old clients should ignore unknown log fields without erroring. Snapshot import applies loot mode and Reward Pot fields only when present.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-823d2573-64fc-4f28-8826-92940a91ab6b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-823d2573-64fc-4f28-8826-92940a91ab6b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

