### PR TITLE
Add /sf version window for raid addon versions

### DIFF
--- a/SpectrumFederation/SpectrumFederation.lua
+++ b/SpectrumFederation/SpectrumFederation.lua
@@ -43,6 +43,10 @@ EventFrame:SetScript("OnEvent", function(self, event, ...)
             SF:RegisterLootHelperSlashCommands()
         end
 
+        if SF.VersionCheck and SF.VersionCheck.Enable then
+            SF.VersionCheck:Enable()
+        end
+
         -- Send a quick message saying that Addon is Initialized
         SF:PrintSuccess("Online. Type /sf to open settings.")
 

--- a/SpectrumFederation/SpectrumFederation.toc
+++ b/SpectrumFederation/SpectrumFederation.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: Spectrum Federation
 ## Author: OsulivanAB
-## Version: 1.1.0
+## Version: 1.2.0-beta.1
 ## Notes: Loot profile management and helper tools for guild coordination. Create and manage raid loot profiles, track distributions, and coordinate gear allocation across your guild.
 ## IconTexture: Interface\AddOns\SpectrumFederation\media\Icons\SpectrumFederationIcon
 ## X-Website: https://github.com/OsulivanAB/SpectrumFederation
@@ -52,6 +52,7 @@ modules/LootHelperSync/17_DebugSlash.lua
 modules/LootHelperSync/18_PublicAPI.lua
 modules/LootHelper/Comm.lua
 modules/RaidCheck.lua
+modules/VersionCheck.lua
 
 modules/Settings/Schema.lua
 modules/Settings/Store.lua
@@ -82,6 +83,7 @@ modules/UI/LootHelper/RosterModel.lua
 modules/UI/LootHelper/RosterView.lua
 modules/UI/LootHelper/EquipmentWindow.lua
 modules/UI/LootHelper/Controller.lua
+modules/UI/VersionCheck/Window.lua
 
 modules/Init.lua
 

--- a/SpectrumFederation/SpectrumFederation.toc
+++ b/SpectrumFederation/SpectrumFederation.toc
@@ -1,7 +1,7 @@
 ## Interface: 120100
 ## Title: Spectrum Federation
 ## Author: OsulivanAB
-## Version: 1.2.0-beta.1
+## Version: 1.2.0-beta.2
 ## Notes: Loot profile management and helper tools for guild coordination. Create and manage raid loot profiles, track distributions, and coordinate gear allocation across your guild.
 ## IconTexture: Interface\AddOns\SpectrumFederation\media\Icons\SpectrumFederationIcon
 ## X-Website: https://github.com/OsulivanAB/SpectrumFederation

--- a/SpectrumFederation/modules/Init.lua
+++ b/SpectrumFederation/modules/Init.lua
@@ -48,6 +48,13 @@ f:SetScript("OnEvent", function(_, _, loadedAddonName)
         SF.RaidCheck:EnsureInspectSupport()
     end
 
+    if SF.VersionCheck and SF.VersionCheck.EnsureSupport then
+        if SF.Debug then
+            SF.Debug:Verbose("INIT", "Initializing addon version check")
+        end
+        SF.VersionCheck:EnsureSupport()
+    end
+
     if SF.Debug then
         SF.Debug:Info("INIT", "All modules initialized successfully")
     end

--- a/SpectrumFederation/modules/UI/VersionCheck/Window.lua
+++ b/SpectrumFederation/modules/UI/VersionCheck/Window.lua
@@ -1,0 +1,610 @@
+-- modules/UI/VersionCheck/Window.lua
+local addonName, SF = ...
+
+-- luacheck: globals CreateFrame UIParent UIPanelCloseButton C_Timer
+
+SF.VersionCheckWindow = SF.VersionCheckWindow or {}
+local Window = SF.VersionCheckWindow
+
+local C = {
+	FRAME_NAME = "SpectrumFederationVersionWindow",
+	TITLE_HEIGHT = 28,
+	TITLE_PADDING_X = 10,
+	CONTENT_PADDING = 10,
+	DEFAULT_POINT = "CENTER",
+	DEFAULT_RELATIVE_POINT = "CENTER",
+	DEFAULT_X = 0,
+	DEFAULT_Y = 0,
+	DEFAULT_WIDTH = 380,
+	DEFAULT_HEIGHT = 460,
+	MIN_WIDTH = 280,
+	MIN_HEIGHT = 220,
+	MAX_WIDTH = 720,
+	MAX_HEIGHT = 860,
+	LOGO_SIZE = 18,
+	ICON_BUTTON_SIZE = 20,
+	RESIZE_HANDLE_SIZE = 16,
+	RESIZE_HANDLE_GAP = 6,
+	SCROLLBAR_GAP = 6,
+	ROW_HEIGHT = 24,
+	ROW_SPACING = 2,
+	CLASS_ICON_SIZE = 20,
+	STATUS_ICON_SIZE = 16,
+	VERSION_WIDTH = 110,
+	HEADER_HEIGHT = 18,
+	STATUS_HEIGHT = 18,
+	MISSING_TEXTURE = "Interface\\RaidFrame\\ReadyCheck-NotReady",
+}
+
+local LISTENER_KEY = (SF.VersionCheck and SF.VersionCheck.WINDOW_LISTENER_KEY) or "version_window"
+
+local function Clamp(v, minV, maxV)
+	v = tonumber(v) or minV
+	if v < minV then return minV end
+	if v > maxV then return maxV end
+	return v
+end
+
+local function Round(v)
+	v = tonumber(v) or 0
+	return math.floor(v + 0.5)
+end
+
+local function GetClassIcon(className)
+	local token = type(className) == "string" and className:upper() or nil
+	if token and SF.WOW_CLASSES and SF.WOW_CLASSES[token] and SF.WOW_CLASSES[token].textureFile then
+		return SF.WOW_CLASSES[token].textureFile
+	end
+	return "Interface\\Icons\\INV_Misc_QuestionMark"
+end
+
+function Window:_GetWindowStateTable()
+	SpectrumFederationDB = SpectrumFederationDB or {}
+	SpectrumFederationDB.versionWindow = SpectrumFederationDB.versionWindow or {}
+	return SpectrumFederationDB.versionWindow
+end
+
+function Window:_ApplyResizeBounds(frame)
+	if not frame then return end
+
+	frame:SetResizable(true)
+	if frame.SetResizeBounds then
+		frame:SetResizeBounds(C.MIN_WIDTH, C.MIN_HEIGHT, C.MAX_WIDTH, C.MAX_HEIGHT)
+	else
+		if frame.SetMinResize then frame:SetMinResize(C.MIN_WIDTH, C.MIN_HEIGHT) end
+		if frame.SetMaxResize then frame:SetMaxResize(C.MAX_WIDTH, C.MAX_HEIGHT) end
+	end
+end
+
+function Window:ClampSizeToBounds()
+	local f = self._frame
+	if not f then return end
+
+	local w, h = f:GetSize()
+	f:SetSize(Clamp(w, C.MIN_WIDTH, C.MAX_WIDTH), Clamp(h, C.MIN_HEIGHT, C.MAX_HEIGHT))
+end
+
+function Window:EnsureOnScreen()
+	local f = self._frame
+	if not f then return end
+
+	local uiW = UIParent:GetWidth()
+	local uiH = UIParent:GetHeight()
+	if not uiW or not uiH or uiW <= 0 or uiH <= 0 then return end
+
+	local left, right, top, bottom = f:GetLeft(), f:GetRight(), f:GetTop(), f:GetBottom()
+	if not left or not right or not top or not bottom then return end
+
+	if left < 0 or right > uiW or bottom < 0 or top > uiH then
+		f:ClearAllPoints()
+		f:SetPoint(C.DEFAULT_POINT, UIParent, C.DEFAULT_RELATIVE_POINT, C.DEFAULT_X, C.DEFAULT_Y)
+	end
+end
+
+function Window:LoadState()
+	local f = self._frame
+	if not f then return end
+
+	local st = self:_GetWindowStateTable()
+	local w = Clamp(st.width or C.DEFAULT_WIDTH, C.MIN_WIDTH, C.MAX_WIDTH)
+	local h = Clamp(st.height or C.DEFAULT_HEIGHT, C.MIN_HEIGHT, C.MAX_HEIGHT)
+	f:SetSize(w, h)
+
+	local point = st.point or C.DEFAULT_POINT
+	local relativePoint = st.relativePoint or C.DEFAULT_RELATIVE_POINT
+	local x = tonumber(st.x) or C.DEFAULT_X
+	local y = tonumber(st.y) or C.DEFAULT_Y
+	f:ClearAllPoints()
+	f:SetPoint(point, UIParent, relativePoint, x, y)
+
+	if SF.Debug then
+		SF.Debug:Verbose("VERSION_CHECK", "LoadState: size=%dx%d, position=%s->%s at (%d,%d)", w, h, point, relativePoint, x, y)
+	end
+
+	if C_Timer and C_Timer.After then
+		C_Timer.After(0, function()
+			self:EnsureOnScreen()
+		end)
+	else
+		self:EnsureOnScreen()
+	end
+end
+
+function Window:SaveState()
+	local f = self._frame
+	if not f then return end
+
+	self:ClampSizeToBounds()
+
+	local st = self:_GetWindowStateTable()
+	local w, h = f:GetSize()
+	local point, _, relPoint, x, y = f:GetPoint(1)
+
+	st.width = Round(w)
+	st.height = Round(h)
+	st.point = point or C.DEFAULT_POINT
+	st.relativePoint = relPoint or C.DEFAULT_RELATIVE_POINT
+	st.x = Round(x)
+	st.y = Round(y)
+
+	if SF.Debug then
+		SF.Debug:Verbose("VERSION_CHECK", "SaveState: size=%dx%d, position=%s->%s at (%d,%d)", st.width, st.height, st.point, st.relativePoint, st.x, st.y)
+	end
+end
+
+function Window:RequestScrollInsetsUpdate()
+	local f = self._frame
+	if not f then return end
+	if f.__sfScrollInsetsScheduled then return end
+	f.__sfScrollInsetsScheduled = true
+
+	local function Run()
+		local f2 = self._frame
+		if not f2 then return end
+		f2.__sfScrollInsetsScheduled = false
+		self:UpdateScrollInsets()
+	end
+
+	if C_Timer and C_Timer.After then
+		C_Timer.After(0, Run)
+	else
+		Run()
+	end
+end
+
+function Window:UpdateScrollInsets()
+	local f = self._frame
+	if not f or not f.Content or not f.Content.Scroll then return end
+
+	local content = f.Content
+	local scroll = content.Scroll
+	local sb = scroll.ScrollBar
+
+	local range = 0
+	if scroll.GetVerticalScrollRange then
+		range = scroll:GetVerticalScrollRange() or 0
+	end
+	local needScroll = range > 0.5
+
+	if sb then
+		sb:SetShown(needScroll)
+	end
+	if not needScroll and scroll.SetVerticalScroll then
+		scroll:SetVerticalScroll(0)
+	end
+
+	local rightInset = 0
+	if needScroll and sb then
+		local sbw = sb:GetWidth() or 0
+		if sbw < 16 then sbw = 20 end
+		rightInset = sbw + C.SCROLLBAR_GAP
+	end
+
+	local bottomInset = 0
+	if f.ResizeHandle and f.ResizeHandle:IsShown() then
+		bottomInset = (f.ResizeHandle:GetHeight() or C.RESIZE_HANDLE_SIZE) + C.RESIZE_HANDLE_GAP
+	end
+
+	local topInset = C.HEADER_HEIGHT
+	local status = content.StatusText
+	if status and status:IsShown() then
+		bottomInset = bottomInset + C.STATUS_HEIGHT
+	end
+
+	scroll:ClearAllPoints()
+	scroll:SetPoint("TOPLEFT", content, "TOPLEFT", 0, -topInset)
+	scroll:SetPoint("BOTTOMRIGHT", content, "BOTTOMRIGHT", -rightInset, bottomInset)
+
+	if scroll.GetVerticalScroll and scroll.SetVerticalScroll and scroll.GetVerticalScrollRange then
+		local cur = scroll:GetVerticalScroll() or 0
+		local maxRange = scroll:GetVerticalScrollRange() or 0
+		if cur > maxRange then
+			scroll:SetVerticalScroll(maxRange)
+		end
+	end
+end
+
+function Window:_EnsureRow(index)
+	self._rows = self._rows or {}
+	if self._rows[index] then
+		return self._rows[index]
+	end
+
+	local child = self._frame.Content.Child
+	local row = CreateFrame("Frame", nil, child)
+	row:SetHeight(C.ROW_HEIGHT)
+
+	local highlight = row:CreateTexture(nil, "BACKGROUND")
+	highlight:SetAllPoints(row)
+	highlight:SetColorTexture(1, 1, 1, 0.03)
+	row.Highlight = highlight
+
+	local icon = row:CreateTexture(nil, "ARTWORK")
+	icon:SetSize(C.CLASS_ICON_SIZE, C.CLASS_ICON_SIZE)
+	icon:SetPoint("LEFT", row, "LEFT", 4, 0)
+	icon:SetTexCoord(0.07, 0.93, 0.07, 0.93)
+	row.Icon = icon
+
+	local missing = row:CreateTexture(nil, "ARTWORK")
+	missing:SetSize(C.STATUS_ICON_SIZE, C.STATUS_ICON_SIZE)
+	missing:SetPoint("RIGHT", row, "RIGHT", -6, 0)
+	missing:SetTexture(C.MISSING_TEXTURE)
+	row.Missing = missing
+
+	local version = row:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+	version:SetJustifyH("RIGHT")
+	version:SetWidth(C.VERSION_WIDTH)
+	version:SetWordWrap(false)
+	version:SetMaxLines(1)
+	version:SetPoint("RIGHT", missing, "LEFT", -4, 0)
+	row.Version = version
+
+	local name = row:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+	name:SetJustifyH("LEFT")
+	name:SetWordWrap(false)
+	name:SetMaxLines(1)
+	name:SetPoint("LEFT", icon, "RIGHT", 8, 0)
+	name:SetPoint("RIGHT", version, "LEFT", -8, 0)
+	row.Name = name
+
+	self._rows[index] = row
+	self:_ApplyRowStyle(row)
+	return row
+end
+
+function Window:_ApplyRowStyle(row)
+	if not row then return end
+	if not (self._fontPath and self._fontSize) then return end
+	if row.Name and row.Name.SetFont then
+		row.Name:SetFont(self._fontPath, self._fontSize, "")
+	end
+	if row.Version and row.Version.SetFont then
+		row.Version:SetFont(self._fontPath, math.max(8, self._fontSize - 1), "")
+	end
+end
+
+function Window:ApplyStyle()
+	local f = self._frame
+	if not f then return end
+
+	local style = SF.LootHelperWindow and SF.LootHelperWindow.Style
+	if style and style.ApplyWindowStyle then
+		style:ApplyWindowStyle(f)
+	end
+
+	if style and style.ResolveFont then
+		self._fontPath, self._fontSize = style:ResolveFont()
+	end
+
+	if self._fontPath and self._fontSize then
+		if f.Title and f.Title.Text and f.Title.Text.SetFont then
+			f.Title.Text:SetFont(self._fontPath, self._fontSize + 1, "OUTLINE")
+		end
+		if f.Content and f.Content.HeaderName and f.Content.HeaderName.SetFont then
+			f.Content.HeaderName:SetFont(self._fontPath, math.max(8, self._fontSize - 1), "")
+		end
+		if f.Content and f.Content.HeaderVersion and f.Content.HeaderVersion.SetFont then
+			f.Content.HeaderVersion:SetFont(self._fontPath, math.max(8, self._fontSize - 1), "")
+		end
+		if f.Content and f.Content.StatusText and f.Content.StatusText.SetFont then
+			f.Content.StatusText:SetFont(self._fontPath, math.max(8, self._fontSize - 1), "")
+		end
+		if f.Content and f.Content.EmptyText and f.Content.EmptyText.SetFont then
+			f.Content.EmptyText:SetFont(self._fontPath, self._fontSize, "")
+		end
+	end
+
+	for _, row in ipairs(self._rows or {}) do
+		self:_ApplyRowStyle(row)
+	end
+end
+
+function Window:_SetStatusText(text)
+	local f = self._frame
+	if not f or not f.Content or not f.Content.StatusText then return end
+	f.Content.StatusText:SetText(text or "")
+end
+
+function Window:Refresh()
+	local f = self._frame
+	if not f or not f.Content then return end
+
+	local snapshot = (SF.VersionCheck and SF.VersionCheck.GetSnapshot and SF.VersionCheck:GetSnapshot()) or {
+		rows = {},
+		checking = false,
+		knownCount = 0,
+		totalCount = 0,
+		ownVersion = "Unknown",
+	}
+
+	if f.Title and f.Title.Text then
+		f.Title.Text:SetText("Addon Versions")
+	end
+
+	local rows = snapshot.rows or {}
+	local child = f.Content.Child
+	local y = -2
+
+	if f.Content.EmptyText then
+		if #rows == 0 then
+			f.Content.EmptyText:SetText("No group members to display.")
+			f.Content.EmptyText:Show()
+		else
+			f.Content.EmptyText:Hide()
+		end
+	end
+
+	for i, model in ipairs(rows) do
+		local row = self:_EnsureRow(i)
+		row:ClearAllPoints()
+		row:SetPoint("TOPLEFT", child, "TOPLEFT", 0, y)
+		row:SetPoint("TOPRIGHT", child, "TOPRIGHT", 0, y)
+		row:Show()
+
+		if row.Icon then
+			row.Icon:SetTexture(GetClassIcon(model.class))
+		end
+		if row.Name then
+			row.Name:SetText(model.displayName or model.name or "Unknown")
+		end
+
+		local missing = model.status == "missing"
+		if row.Missing then
+			row.Missing:SetShown(missing)
+		end
+		if row.Version then
+			if missing then
+				row.Version:SetText("")
+				row.Version:SetTextColor(0.9, 0.25, 0.25)
+			elseif model.status == "checking" and not model.version then
+				row.Version:SetText("Checking...")
+				row.Version:SetTextColor(0.72, 0.72, 0.72)
+			else
+				row.Version:SetText(model.version or "")
+				row.Version:SetTextColor(0.92, 0.92, 0.92)
+			end
+		end
+
+		y = y - C.ROW_HEIGHT - C.ROW_SPACING
+	end
+
+	for i = #rows + 1, #(self._rows or {}) do
+		self._rows[i]:Hide()
+	end
+
+	local contentHeight = math.max(1, (#rows * (C.ROW_HEIGHT + C.ROW_SPACING)) + 4)
+	local contentWidth = (f.Content.Scroll and f.Content.Scroll:GetWidth()) or 1
+	child:SetSize(math.max(1, contentWidth), contentHeight)
+
+	if snapshot.checking then
+		self:_SetStatusText("Checking who is running Spectrum Federation...")
+	else
+		self:_SetStatusText(string.format("%d of %d running Spectrum Federation", snapshot.knownCount or 0, snapshot.totalCount or 0))
+	end
+
+	self:RequestScrollInsetsUpdate()
+end
+
+function Window:Create()
+	if self._frame then
+		return self._frame
+	end
+
+	if SF.Debug then
+		SF.Debug:Info("VERSION_CHECK", "Creating addon version window")
+	end
+
+	local frame = CreateFrame("Frame", C.FRAME_NAME, UIParent, "BackdropTemplate")
+	frame:SetSize(C.DEFAULT_WIDTH, C.DEFAULT_HEIGHT)
+	frame:SetPoint(C.DEFAULT_POINT, UIParent, C.DEFAULT_RELATIVE_POINT, C.DEFAULT_X, C.DEFAULT_Y)
+	frame:SetClampedToScreen(true)
+	frame:SetFrameStrata("DIALOG")
+	frame:SetMovable(true)
+	frame:EnableMouse(true)
+	frame:Hide()
+	self:_ApplyResizeBounds(frame)
+
+	frame:SetBackdrop({
+		bgFile = "Interface\\Buttons\\WHITE8X8",
+		edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+		tile = true,
+		tileSize = 8,
+		edgeSize = 12,
+		insets = { left = 4, right = 4, top = 4, bottom = 4 },
+	})
+	frame:SetBackdropColor(0, 0, 0, 0.60)
+	frame:SetBackdropBorderColor(0.65, 0.65, 0.65, 0.65)
+
+	local title = CreateFrame("Frame", nil, frame)
+	title:SetHeight(C.TITLE_HEIGHT)
+	title:SetPoint("TOPLEFT", frame, "TOPLEFT", 6, -6)
+	title:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -6, -6)
+	title:EnableMouse(true)
+	title:RegisterForDrag("LeftButton")
+	title:SetScript("OnDragStart", function()
+		frame:StartMoving()
+	end)
+	title:SetScript("OnDragStop", function()
+		frame:StopMovingOrSizing()
+		Window:SaveState()
+	end)
+	frame.Title = title
+
+	local titleBG = title:CreateTexture(nil, "BACKGROUND")
+	titleBG:SetAllPoints(title)
+	titleBG:SetColorTexture(0.08, 0.08, 0.08, 0.85)
+	title.BG = titleBG
+
+	local logo = title:CreateTexture(nil, "ARTWORK")
+	logo:SetSize(C.LOGO_SIZE, C.LOGO_SIZE)
+	logo:SetPoint("LEFT", title, "LEFT", C.TITLE_PADDING_X, 0)
+	logo:SetTexture("Interface\\AddOns\\SpectrumFederation\\media\\Icons\\SpectrumFederationIcon.tga")
+	title.Logo = logo
+
+	local close = CreateFrame("Button", nil, title, "UIPanelCloseButton")
+	close:SetPoint("RIGHT", title, "RIGHT", -4, 0)
+	close:SetSize(C.ICON_BUTTON_SIZE, C.ICON_BUTTON_SIZE)
+	close:SetScript("OnClick", function()
+		Window:Hide()
+	end)
+	title.Close = close
+
+	local titleText = title:CreateFontString(nil, "ARTWORK", "GameFontHighlight")
+	titleText:SetPoint("LEFT", logo, "RIGHT", 8, 0)
+	titleText:SetPoint("RIGHT", close, "LEFT", -8, 0)
+	titleText:SetJustifyH("LEFT")
+	titleText:SetWordWrap(false)
+	titleText:SetMaxLines(1)
+	titleText:SetText("Addon Versions")
+	title.Text = titleText
+
+	local content = CreateFrame("Frame", nil, frame)
+	content:SetPoint("TOPLEFT", frame, "TOPLEFT", C.CONTENT_PADDING, -(C.TITLE_HEIGHT + C.CONTENT_PADDING + 6))
+	content:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -C.CONTENT_PADDING, C.CONTENT_PADDING)
+	frame.Content = content
+
+	local headerName = content:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+	headerName:SetPoint("TOPLEFT", content, "TOPLEFT", 4, 0)
+	headerName:SetText("Name")
+	headerName:SetTextColor(0.65, 0.78, 0.95, 0.95)
+	content.HeaderName = headerName
+
+	local headerVersion = content:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+	headerVersion:SetPoint("TOPRIGHT", content, "TOPRIGHT", -8, 0)
+	headerVersion:SetText("Version")
+	headerVersion:SetTextColor(0.65, 0.78, 0.95, 0.95)
+	content.HeaderVersion = headerVersion
+
+	local statusText = content:CreateFontString(nil, "ARTWORK", "GameFontDisableSmall")
+	statusText:SetPoint("BOTTOMLEFT", content, "BOTTOMLEFT", 4, 0)
+	statusText:SetPoint("BOTTOMRIGHT", content, "BOTTOMRIGHT", -20, 0)
+	statusText:SetJustifyH("LEFT")
+	statusText:SetText("")
+	content.StatusText = statusText
+
+	local scroll = CreateFrame("ScrollFrame", nil, content, "UIPanelScrollFrameTemplate")
+	content.Scroll = scroll
+	scroll:HookScript("OnScrollRangeChanged", function()
+		Window:RequestScrollInsetsUpdate()
+	end)
+
+	local child = CreateFrame("Frame", nil, scroll)
+	child:SetPoint("TOPLEFT", scroll, "TOPLEFT", 0, 0)
+	child:SetSize(1, 1)
+	scroll:SetScrollChild(child)
+	content.Child = child
+
+	local emptyText = child:CreateFontString(nil, "ARTWORK", "GameFontDisable")
+	emptyText:SetPoint("TOPLEFT", child, "TOPLEFT", 10, -10)
+	emptyText:SetPoint("RIGHT", child, "RIGHT", -10, 0)
+	emptyText:SetJustifyH("LEFT")
+	emptyText:SetJustifyV("TOP")
+	emptyText:SetText("")
+	emptyText:Hide()
+	content.EmptyText = emptyText
+
+	if scroll.HookScript then
+		scroll:HookScript("OnSizeChanged", function()
+			local w = scroll:GetWidth() or 1
+			child:SetWidth(math.max(1, w))
+			Window:RequestScrollInsetsUpdate()
+		end)
+	end
+
+	local resize = CreateFrame("Button", nil, frame)
+	resize:SetSize(C.RESIZE_HANDLE_SIZE, C.RESIZE_HANDLE_SIZE)
+	resize:SetPoint("BOTTOMRIGHT", content, "BOTTOMRIGHT", -2, -2)
+	resize:SetNormalTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Up")
+	resize:SetHighlightTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Highlight")
+	resize:SetPushedTexture("Interface\\ChatFrame\\UI-ChatIM-SizeGrabber-Down")
+	resize:SetScript("OnMouseDown", function(_, button)
+		if button ~= "LeftButton" then return end
+		frame:StartSizing("BOTTOMRIGHT")
+	end)
+	resize:SetScript("OnMouseUp", function(_, button)
+		if button ~= "LeftButton" then return end
+		frame:StopMovingOrSizing()
+		Window:ClampSizeToBounds()
+		Window:SaveState()
+		Window:RequestScrollInsetsUpdate()
+	end)
+	frame.ResizeHandle = resize
+
+	frame:HookScript("OnSizeChanged", function()
+		Window:RequestScrollInsetsUpdate()
+	end)
+
+	self._frame = frame
+	self._rows = {}
+	self:LoadState()
+	self:ApplyStyle()
+	self:RequestScrollInsetsUpdate()
+	return frame
+end
+
+function Window:IsShown()
+	return self._frame and self._frame:IsShown() and true or false
+end
+
+function Window:Show()
+	self:Create()
+	self:ApplyStyle()
+
+	if SF.VersionCheck then
+		if SF.VersionCheck.RegisterListener then
+			SF.VersionCheck:RegisterListener(LISTENER_KEY, function()
+				if Window:IsShown() then
+					Window:Refresh()
+				end
+			end)
+		end
+		if SF.VersionCheck.RequestRefresh then
+			SF.VersionCheck:RequestRefresh("window_show")
+		end
+	end
+
+	self._frame:Show()
+	self:Refresh()
+
+	if SF.Debug then
+		SF.Debug:Info("VERSION_CHECK", "Opened addon version window")
+	end
+end
+
+function Window:Hide()
+	if SF.VersionCheck and SF.VersionCheck.UnregisterListener then
+		SF.VersionCheck:UnregisterListener(LISTENER_KEY)
+	end
+	if self._frame then
+		self:SaveState()
+		self._frame:Hide()
+	end
+end
+
+function Window:Toggle()
+	if self:IsShown() then
+		self:Hide()
+	else
+		self:Show()
+	end
+end

--- a/SpectrumFederation/modules/VersionCheck.lua
+++ b/SpectrumFederation/modules/VersionCheck.lua
@@ -1,0 +1,685 @@
+-- Grab the namespace
+local addonName, SF = ...
+
+-- luacheck: globals CreateFrame C_ChatInfo C_Timer GetTime GetNumGroupMembers time
+-- luacheck: globals IsInRaid IsInGroup UnitFullName UnitClass UnitExists UnitIsUnit UnitIsConnected
+-- luacheck: globals GetRealmName C_AddOns GetAddOnMetadata
+
+-- Lightweight raid/party version roster.
+-- Prefix: SF_VER
+-- PING:<nonce>:<version>  (broadcast on RAID/PARTY)
+-- PONG:<nonce>:<version>  (whispered back to the requester)
+SF.VersionCheck = SF.VersionCheck or {}
+local VC = SF.VersionCheck
+
+local PREFIX = "SF_VER"
+local MSG_PING = "PING"
+local MSG_PONG = "PONG"
+local REPLY_TIMEOUT_SECONDS = 2.5
+local PING_MIN_INTERVAL_SECONDS = 2
+local LISTENER_KEY = "version_window"
+
+local function DebugInfo(fmt, ...)
+	if SF.Debug then
+		SF.Debug:Info("VERSION_CHECK", fmt, ...)
+	end
+end
+
+local function DebugVerbose(fmt, ...)
+	if SF.Debug then
+		SF.Debug:Verbose("VERSION_CHECK", fmt, ...)
+	end
+end
+
+local function DebugWarn(fmt, ...)
+	if SF.Debug then
+		SF.Debug:Warn("VERSION_CHECK", fmt, ...)
+	end
+end
+
+local function DebugError(fmt, ...)
+	if SF.Debug then
+		SF.Debug:Error("VERSION_CHECK", fmt, ...)
+	end
+end
+
+local function Now()
+	return (GetTime and GetTime()) or (time and time()) or 0
+end
+
+local function GetOwnVersion()
+	if SF.GetAddonVersion then
+		return SF:GetAddonVersion() or "Unknown"
+	end
+	if C_AddOns and C_AddOns.GetAddOnMetadata then
+		return C_AddOns.GetAddOnMetadata(addonName, "Version") or "Unknown"
+	end
+	if GetAddOnMetadata then
+		return GetAddOnMetadata(addonName, "Version") or "Unknown"
+	end
+	return "Unknown"
+end
+
+local function SanitizeToken(value, fallback)
+	if type(value) ~= "string" then
+		return fallback
+	end
+	value = value:gsub("[\r\n:]", ""):gsub("^%s+", ""):gsub("%s+$", "")
+	if value == "" then
+		return fallback
+	end
+	if #value > 64 then
+		value = value:sub(1, 64)
+	end
+	return value
+end
+
+local function NormalizeNameRealm(name, realm)
+	if not name or name == "" then
+		return nil
+	end
+	local full = name
+	if realm and realm ~= "" then
+		full = name .. "-" .. realm
+	end
+	if SF.NameUtil and SF.NameUtil.NormalizeNameRealm then
+		return SF.NameUtil.NormalizeNameRealm(full) or full
+	end
+	if realm and realm ~= "" then
+		realm = realm:gsub("%s+", "")
+		return name .. "-" .. realm
+	end
+	local defaultRealm = GetRealmName and GetRealmName() or nil
+	if defaultRealm then
+		defaultRealm = defaultRealm:gsub("%s+", "")
+		return name .. "-" .. defaultRealm
+	end
+	return name
+end
+
+local function ShortName(full)
+	if type(full) ~= "string" then
+		return "Unknown"
+	end
+	return full:match("^[^%-]+") or full
+end
+
+local function SamePlayer(a, b)
+	if SF.NameUtil and SF.NameUtil.SamePlayer then
+		return SF.NameUtil.SamePlayer(a, b)
+	end
+	if type(a) ~= "string" or type(b) ~= "string" then
+		return false
+	end
+	return a:lower() == b:lower()
+end
+
+local function SelfId()
+	if SF.NameUtil and SF.NameUtil.GetSelfId then
+		return SF.NameUtil.GetSelfId()
+	end
+	if SF.GetPlayerFullIdentifier then
+		return SF:GetPlayerFullIdentifier()
+	end
+	local name, realm = UnitFullName and UnitFullName("player")
+	return NormalizeNameRealm(name, realm)
+end
+
+local function ToWoWHexColor(color)
+	if type(color) == "table" then
+		local r = tonumber(color.r or color[1] or 1) or 1
+		local g = tonumber(color.g or color[2] or 1) or 1
+		local b = tonumber(color.b or color[3] or 1) or 1
+		r = math.min(math.max(r, 0), 1)
+		g = math.min(math.max(g, 0), 1)
+		b = math.min(math.max(b, 0), 1)
+		return string.format("|cff%02x%02x%02x", r * 255, g * 255, b * 255)
+	end
+	return "|cffffffff"
+end
+
+local function ColorizeUnitName(unit, name)
+	if not unit or not name or name == "" then
+		return name or "Unknown"
+	end
+	local _, classToken = UnitClass(unit)
+	local classData = classToken and SF.WOW_CLASSES and SF.WOW_CLASSES[classToken]
+	if classData and classData.colorCode then
+		return string.format("%s%s|r", ToWoWHexColor(classData.colorCode), name)
+	end
+	return name
+end
+
+local function CollectUnits()
+	local units = {}
+	if IsInRaid and IsInRaid() then
+		for i = 1, (GetNumGroupMembers() or 0) do
+			table.insert(units, "raid" .. i)
+		end
+	elseif IsInGroup and IsInGroup() then
+		for i = 1, (GetNumGroupMembers() or 1) - 1 do
+			table.insert(units, "party" .. i)
+		end
+		table.insert(units, "player")
+	else
+		table.insert(units, "player")
+	end
+	return units
+end
+
+local function GetGroupDistribution()
+	if IsInRaid and IsInRaid() then
+		return "RAID"
+	end
+	if IsInGroup and IsInGroup() then
+		return "PARTY"
+	end
+	return nil
+end
+
+local function IsSelfUnit(unit)
+	if not unit then
+		return false
+	end
+	if unit == "player" then
+		return true
+	end
+	if UnitIsUnit then
+		return UnitIsUnit(unit, "player") and true or false
+	end
+	return false
+end
+
+local function IsUnitOnline(unit)
+	if not unit then
+		return false
+	end
+	if IsSelfUnit(unit) then
+		return true
+	end
+	if UnitIsConnected then
+		local connected = UnitIsConnected(unit)
+		if connected == nil then
+			return true
+		end
+		return connected and true or false
+	end
+	return true
+end
+
+local function GetPeerAddonVersion(id)
+	local sync = SF.LootHelperSync
+	if not (id and sync and sync.state and type(sync.state.peers) == "table") then
+		return nil
+	end
+
+	local peer = sync.state.peers[id]
+	if type(peer) == "table" and type(peer.addonVersion) == "string" and peer.addonVersion ~= "" and peer.addonVersion ~= "unknown" then
+		return peer.addonVersion
+	end
+
+	for name, other in pairs(sync.state.peers) do
+		if type(other) == "table" and SamePlayer(name, id) then
+			if type(other.addonVersion) == "string" and other.addonVersion ~= "" and other.addonVersion ~= "unknown" then
+				return other.addonVersion
+			end
+		end
+	end
+
+	return nil
+end
+
+function VC:_GetState()
+	self._state = self._state or {
+		entries = {},
+		order = {},
+		nonce = 0,
+		activeNonce = nil,
+		activeRound = 0,
+		lastPingAt = 0,
+		snapshotVersion = 0,
+		lastNotifiedVersion = -1,
+		listeners = {},
+		timeoutHandle = nil,
+		slashRegistered = false,
+	}
+	return self._state
+end
+
+function VC:_MarkDirty()
+	local state = self:_GetState()
+	state.snapshotVersion = (state.snapshotVersion or 0) + 1
+	return state.snapshotVersion
+end
+
+function VC:_NotifyListeners(force)
+	local state = self:_GetState()
+	local version = state.snapshotVersion or 0
+	if not force and state.lastNotifiedVersion == version then
+		return version
+	end
+
+	state.lastNotifiedVersion = version
+	for _, callback in pairs(state.listeners) do
+		pcall(callback, version)
+	end
+	return version
+end
+
+function VC:RegisterListener(key, callback)
+	if not key or type(callback) ~= "function" then
+		return
+	end
+	self:_GetState().listeners[key] = callback
+end
+
+function VC:UnregisterListener(key)
+	if not key then
+		return
+	end
+	self:_GetState().listeners[key] = nil
+end
+
+function VC:_GetOrCreateEntry(id)
+	local state = self:_GetState()
+	local entry = state.entries[id]
+	if not entry then
+		entry = {
+			id = id,
+			name = ShortName(id),
+			displayName = ShortName(id),
+			class = nil,
+			unit = nil,
+			online = true,
+			status = "missing",
+			version = nil,
+			answeredRound = 0,
+		}
+		state.entries[id] = entry
+	end
+	return entry
+end
+
+function VC:_RebuildRoster()
+	local state = self:_GetState()
+	local seen = {}
+	local order = {}
+
+	for _, unit in ipairs(CollectUnits()) do
+		if UnitExists and UnitExists(unit) then
+			local name, realm = UnitFullName(unit)
+			local id = NormalizeNameRealm(name, realm)
+			if id then
+				local entry = self:_GetOrCreateEntry(id)
+				local _, classToken = UnitClass(unit)
+				local isNew = entry.unit == nil and entry.answeredRound == 0 and entry.version == nil
+				entry.unit = unit
+				entry.class = classToken
+				entry.name = ShortName(id)
+				entry.displayName = ColorizeUnitName(unit, entry.name)
+				entry.online = IsUnitOnline(unit)
+				if isNew then
+					if SamePlayer(id, SelfId()) then
+						entry.version = GetOwnVersion()
+						entry.status = "known"
+						entry.answeredRound = state.activeRound or 0
+					elseif entry.online and (state.activeNonce or false) then
+						entry.status = "checking"
+					elseif not entry.online then
+						entry.status = "missing"
+					end
+				end
+				seen[id] = true
+				order[#order + 1] = id
+			end
+		end
+	end
+
+	for id, entry in pairs(state.entries) do
+		if not seen[id] then
+			state.entries[id] = nil
+		else
+			entry.id = id
+		end
+	end
+
+	state.order = order
+	self:_MarkDirty()
+end
+
+function VC:_RecordVersion(id, version, round)
+	if type(id) ~= "string" or id == "" then
+		return
+	end
+
+	version = SanitizeToken(version, nil)
+	if not version then
+		return
+	end
+
+	local entry = self:_GetOrCreateEntry(id)
+	entry.version = version
+	entry.status = "known"
+	if round then
+		entry.answeredRound = round
+	end
+	self:_MarkDirty()
+	self:_NotifyListeners()
+end
+
+function VC:_NextNonce()
+	local state = self:_GetState()
+	state.nonce = (state.nonce or 0) + 1
+	return string.format("%d-%d", state.nonce, math.floor(Now() * 1000))
+end
+
+function VC:_PackMessage(kind, nonce, version)
+	return string.format("%s:%s:%s", kind, nonce, SanitizeToken(version, GetOwnVersion()))
+end
+
+function VC:_ParseMessage(text)
+	if type(text) ~= "string" or text == "" then
+		return nil
+	end
+	local kind, nonce, version = text:match("^(%u+):([^:]+):(.*)$")
+	if not kind or not nonce then
+		return nil
+	end
+	version = SanitizeToken(version, nil)
+	return kind, nonce, version
+end
+
+function VC:_Send(message, distribution, target)
+	if not (C_ChatInfo and C_ChatInfo.SendAddonMessage) then
+		DebugError("SendAddonMessage is unavailable")
+		return false
+	end
+	if type(message) ~= "string" or message == "" or type(distribution) ~= "string" then
+		return false
+	end
+
+	local ok, result = pcall(C_ChatInfo.SendAddonMessage, PREFIX, message, distribution, target)
+	if not ok then
+		DebugWarn("Failed to send %s via %s: %s", message, distribution, tostring(result))
+		return false
+	end
+	return result ~= false
+end
+
+function VC:_SendPong(target, nonce)
+	if type(target) ~= "string" or target == "" or type(nonce) ~= "string" then
+		return
+	end
+	self:_Send(self:_PackMessage(MSG_PONG, nonce, GetOwnVersion()), "WHISPER", target)
+end
+
+function VC:_FinishRound(round)
+	local state = self:_GetState()
+	if state.activeRound ~= round then
+		return
+	end
+
+	for _, id in ipairs(state.order) do
+		local entry = state.entries[id]
+		if entry and entry.answeredRound ~= round then
+			if SamePlayer(id, SelfId()) then
+				entry.version = GetOwnVersion()
+				entry.status = "known"
+				entry.answeredRound = round
+			else
+				local seeded = GetPeerAddonVersion(id)
+				if seeded then
+					entry.version = seeded
+					entry.status = "known"
+				else
+					entry.version = nil
+					entry.status = "missing"
+				end
+			end
+		end
+	end
+
+	DebugInfo("Version check round %d finished (%d players)", round, #state.order)
+	self:_MarkDirty()
+	self:_NotifyListeners(true)
+end
+
+function VC:_ScheduleRoundTimeout(round)
+	local state = self:_GetState()
+	if state.timeoutHandle and state.timeoutHandle.Cancel then
+		pcall(function()
+			state.timeoutHandle:Cancel()
+		end)
+	end
+	state.timeoutHandle = nil
+
+	local function expire()
+		local current = self:_GetState()
+		current.timeoutHandle = nil
+		self:_FinishRound(round)
+	end
+
+	if C_Timer and C_Timer.NewTimer then
+		state.timeoutHandle = C_Timer.NewTimer(REPLY_TIMEOUT_SECONDS, expire)
+	elseif C_Timer and C_Timer.After then
+		C_Timer.After(REPLY_TIMEOUT_SECONDS, expire)
+	else
+		expire()
+	end
+end
+
+function VC:RequestRefresh(reason)
+	self:EnsureSupport()
+	self:_RebuildRoster()
+
+	local state = self:_GetState()
+	local now = Now()
+	if (now - (state.lastPingAt or 0)) < PING_MIN_INTERVAL_SECONDS and state.activeNonce then
+		self:_NotifyListeners(true)
+		return
+	end
+
+	local round = (state.activeRound or 0) + 1
+	local nonce = self:_NextNonce()
+	state.activeRound = round
+	state.activeNonce = nonce
+	state.lastPingAt = now
+
+	local me = SelfId()
+	local ownVersion = GetOwnVersion()
+	for _, id in ipairs(state.order) do
+		local entry = state.entries[id]
+		if entry then
+			if SamePlayer(id, me) then
+				entry.version = ownVersion
+				entry.status = "known"
+				entry.answeredRound = round
+				entry.online = true
+			else
+				local seeded = GetPeerAddonVersion(id)
+				if seeded then
+					entry.version = seeded
+					entry.status = "known"
+				end
+				if entry.online then
+					if entry.answeredRound ~= round then
+						entry.status = entry.version and "known" or "checking"
+					end
+				else
+					if not entry.version then
+						entry.status = "missing"
+					end
+					entry.answeredRound = round
+				end
+			end
+		end
+	end
+
+	self:_MarkDirty()
+	self:_NotifyListeners(true)
+
+	local dist = GetGroupDistribution()
+	if dist then
+		local sent = self:_Send(self:_PackMessage(MSG_PING, nonce, ownVersion), dist)
+		DebugInfo("Broadcast version ping (reason=%s, dist=%s, nonce=%s, sent=%s)", tostring(reason or "manual"), dist, nonce, tostring(sent))
+		self:_ScheduleRoundTimeout(round)
+	else
+		self:_FinishRound(round)
+	end
+end
+
+function VC:_HandlePing(senderId, nonce, version, whisperTarget)
+	if SamePlayer(senderId, SelfId()) then
+		return
+	end
+
+	local state = self:_GetState()
+	self:_RebuildRoster()
+	self:_RecordVersion(senderId, version, state.activeRound)
+	self:_SendPong(whisperTarget or senderId, nonce)
+	DebugVerbose("Responded to version ping from %s (nonce=%s, version=%s)", tostring(senderId), tostring(nonce), tostring(version))
+end
+
+function VC:_HandlePong(senderId, nonce, version)
+	local state = self:_GetState()
+	if state.activeNonce and nonce ~= state.activeNonce then
+		return
+	end
+
+	self:_RebuildRoster()
+	self:_RecordVersion(senderId, version, state.activeRound)
+	DebugVerbose("Received version pong from %s (version=%s)", tostring(senderId), tostring(version))
+end
+
+function VC:_OnAddonMessage(prefix, text, _, sender)
+	if prefix ~= PREFIX or type(text) ~= "string" then
+		return
+	end
+
+	local senderId = NormalizeNameRealm(sender)
+	if not senderId then
+		return
+	end
+	if SamePlayer(senderId, SelfId()) then
+		return
+	end
+
+	local kind, nonce, version = self:_ParseMessage(text)
+	if not kind or not nonce then
+		DebugVerbose("Ignored malformed version message from %s", tostring(sender))
+		return
+	end
+
+	if kind == MSG_PING then
+		self:_HandlePing(senderId, nonce, version, sender)
+	elseif kind == MSG_PONG then
+		self:_HandlePong(senderId, nonce, version)
+	end
+end
+
+function VC:_OnGroupRosterUpdate()
+	self:_RebuildRoster()
+	self:_NotifyListeners()
+
+	local window = SF.VersionCheckWindow
+	if window and window.IsShown and window:IsShown() then
+		self:RequestRefresh("roster_update")
+	end
+end
+
+function VC:EnsureSupport()
+	if self._frame then
+		return
+	end
+
+	if C_ChatInfo and C_ChatInfo.RegisterAddonMessagePrefix then
+		local ok, result = pcall(C_ChatInfo.RegisterAddonMessagePrefix, PREFIX)
+		if not ok then
+			DebugWarn("RegisterAddonMessagePrefix(%s) failed: %s", PREFIX, tostring(result))
+		end
+	end
+
+	local frame = CreateFrame("Frame")
+	self._frame = frame
+	frame:RegisterEvent("CHAT_MSG_ADDON")
+	frame:RegisterEvent("GROUP_ROSTER_UPDATE")
+	frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+	frame:SetScript("OnEvent", function(_, event, ...)
+		if event == "CHAT_MSG_ADDON" then
+			self:_OnAddonMessage(...)
+		elseif event == "GROUP_ROSTER_UPDATE" or event == "PLAYER_ENTERING_WORLD" then
+			self:_OnGroupRosterUpdate()
+		end
+	end)
+
+	self:_RebuildRoster()
+	DebugInfo("Version check support initialized")
+end
+
+function VC:GetSnapshot()
+	self:EnsureSupport()
+	self:_RebuildRoster()
+
+	local state = self:_GetState()
+	local rows = {}
+	local knownCount = 0
+	local checking = false
+
+	for _, id in ipairs(state.order) do
+		local entry = state.entries[id]
+		if entry then
+			if entry.status == "known" then
+				knownCount = knownCount + 1
+			elseif entry.status == "checking" then
+				checking = true
+			end
+			rows[#rows + 1] = {
+				id = entry.id,
+				name = entry.name,
+				displayName = entry.displayName or entry.name,
+				class = entry.class,
+				unit = entry.unit,
+				online = entry.online and true or false,
+				status = entry.status,
+				version = entry.version,
+			}
+		end
+	end
+
+	return {
+		version = state.snapshotVersion or 0,
+		checking = checking,
+		knownCount = knownCount,
+		totalCount = #rows,
+		ownVersion = GetOwnVersion(),
+		rows = rows,
+	}
+end
+
+function VC:ShowWindow()
+	self:EnsureSupport()
+	if SF.VersionCheckWindow and SF.VersionCheckWindow.Show then
+		SF.VersionCheckWindow:Show()
+	else
+		if SF.PrintError then
+			SF:PrintError("Addon version window is not available.")
+		end
+		DebugError("VersionCheckWindow is missing")
+	end
+end
+
+function VC:Enable()
+	self:EnsureSupport()
+
+	local state = self:_GetState()
+	if not state.slashRegistered and SF.RegisterSlashCommand then
+		SF:RegisterSlashCommand("version", function()
+			self:ShowWindow()
+		end, "Show who in the group is running Spectrum Federation")
+		state.slashRegistered = true
+		DebugInfo("Registered /sf version")
+	end
+end
+
+-- Keep a stable listener key for the window without exposing internals.
+VC.WINDOW_LISTENER_KEY = LISTENER_KEY

--- a/SpectrumFederation/modules/VersionCheck.lua
+++ b/SpectrumFederation/modules/VersionCheck.lua
@@ -439,6 +439,17 @@ function VC:_FinishRound(round)
 		end
 	end
 
+	-- Drop the round nonce so idle roster updates do not keep treating the
+	-- last query as in-progress (new joiners would otherwise stay "checking",
+	-- and RequestRefresh would keep applying the in-flight ping throttle).
+	if state.timeoutHandle and state.timeoutHandle.Cancel then
+		pcall(function()
+			state.timeoutHandle:Cancel()
+		end)
+	end
+	state.timeoutHandle = nil
+	state.activeNonce = nil
+
 	DebugInfo("Version check round %d finished (%d players)", round, #state.order)
 	self:_MarkDirty()
 	self:_NotifyListeners(true)

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -30,6 +30,7 @@ local addonName, SF = ...
 | `modules/LootHelperSync/` | Session state, validation, requests, convergence, heartbeat, routing, bulk handlers, and public API. |
 | `modules/UI/LootHelper/` | Roster/equipment presentation and controller logic. |
 | `modules/RaidCheck.lua` | Inspection cache, equipment evaluation, whispers, snapshots, and point awards. |
+| `modules/VersionCheck.lua` | Raid/party addon-version query, roster snapshot, and `/sf version` window. |
 
 ## Persistent data
 

--- a/docs/development/getting-started/index.md
+++ b/docs/development/getting-started/index.md
@@ -15,6 +15,8 @@ SpectrumFederation/
     UI/Settings/               standalone settings framework and pages
     UI/LootHelper/             roster and equipment windows
     RaidCheck.lua              inspection, preparation checks, and awards
+    VersionCheck.lua           raid/party addon-version query
+    UI/VersionCheck/           resizable `/sf version` window
   locale/                      early localization work (not currently loaded by the TOC)
 .github/scripts/               validation and release helpers
 .github/workflows/             PR, beta, promotion, and rollback automation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,7 @@ See [Raid Check](features/raid-check.md) before enabling automatic whispers or a
 - `/sf profiles` — list local profiles.
 - `/sf raidcheck pre` — run a pre-raid check.
 - `/sf raidcheck raid` — run the awarding raid check.
+- `/sf version` — show who in the raid or party is running Spectrum Federation, and which version.
 - `/sf loot sync` — manually compare your data with the active session.
 
 The [Slash Command Reference](reference/slash-commands.md) lists every supported command and restriction.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Spectrum Federation is a World of Warcraft Retail addon for coordinating guild r
 - **Loot profiles** — separate, named sets of members, admins, Point Based or Reward Pot rules, Raid Check options, and history.
 - **Sync sessions** — group-wide profile and log synchronization, with automatic catch-up for late joiners and clients that missed updates.
 - **Raid Check** — configurable enchant and gem checks, optional whispers, and loot-point or Attendance awards for prepared profile members.
+- **Addon versions** — `/sf version` lists current raid or party members and the Spectrum Federation version each one is running.
 - **Loot Logs** — a filterable history of point, Attendance, Reward Pot, equipment, profile, safe-mode, admin, and main-swap changes.
 - **Gameplay settings** — per-specialization control of WoW's Press and Hold Casting option.
 

--- a/docs/reference/slash-commands.md
+++ b/docs/reference/slash-commands.md
@@ -41,6 +41,14 @@ Any other text after `/sf loot` currently performs the same default action as `/
 
 Both modes require an active profile and profile-admin permission. Entering another argument prints the supported syntax.
 
+## Addon versions
+
+| Command | Result |
+| --- | --- |
+| `/sf version` | Open a resizable window listing current raid or party members and the Spectrum Federation version each one is running. Players who do not respond receive a red X. |
+
+The window remembers its size and position, and it can be closed with the title-bar X. Use the command again to refresh the list. Solo players see only themselves.
+
 ## Debugging
 
 | Command | Aliases | Result |

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -51,6 +51,18 @@ WoW throttles inspection and requires other players to be nearby and inspectable
 
 Raid Check treats incomplete item data as unprepared. Move closer, refresh the snapshot, then rerun the check.
 
+## `/sf version` shows a red X for someone who has the addon
+
+The version window asks current group members to report the addon version they are running. A red X means that player did not answer in time.
+
+Common causes:
+
+- the player does not have Spectrum Federation enabled;
+- the player is offline or still loading;
+- the player is on an older build that does not answer version queries.
+
+Run `/sf version` again after they reload. Your own row always shows the version from this client.
+
 ## A player did not receive a Raid Check point or Attendance
 
 Confirm that:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `/sf version`, which opens a resizable window listing everyone in the current raid or party, the Spectrum Federation version they are running, and a red X when they do not have the addon (or do not answer).

The window uses the existing Loot Helper look, has a title-bar close button, and remembers its size and position.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code improvement without functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## Changes Made

- Added a lightweight `SF_VER` ping/pong query so clients can report their addon version without a Loot Helper session.
- Added a resizable version roster window that matches Loot Helper styling, including the close X and persisted size/position.
- Registered `/sf version` and documented the command.
- Bumped the TOC version to `1.2.0-beta.1`.

## Checklist

- [x] I have tested these changes in-game
- [x] My code follows the project's style guidelines
- [x] I have added/updated documentation as needed
- [x] I have added appropriate Debug Logging if necessary
- [x] I have added/updated localization strings in `locale/enUS.lua` if applicable
- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been merged and published
- [x] I've linked this PR to any related issues in the [repo project](https://github.com/users/OsulivanAB/projects/1).

## Testing

### In-Game Testing Details

**WoW Client Type:**
- [x] Retail
- [ ] Classic
- [ ] PTR
- [ ] Beta

**Game Version:** Interface 120100

**Additional Testing Info**

Local validation passed:

- `python3 .github/scripts/lint_all.py` (luacheck 0 warnings / 0 errors)
- `python3 .github/scripts/validate_packaging.py`
- `python3 .github/scripts/validate_docs.py`
- `python3 .github/scripts/check_version_bump.py beta` (`1.1.0` -> `1.2.0-beta.1`)
- `luac -p` on the new Lua files

`locale/enUS.lua` is not loaded by the TOC, so window text follows the existing hardcoded English UI pattern. Full raid verification still needs a Retail client: `/sf version` in a raid/party, resize + reload for persisted size, and confirm a player without the addon shows a red X.

## Additional Notes

No extra settings, sync-protocol, or Loot Helper behavior changes were included.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55d7e14c-0515-4ccc-a621-f7d6a2073443?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55d7e14c-0515-4ccc-a621-f7d6a2073443&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

